### PR TITLE
[style guide] Intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,19 +69,3 @@ By definition, members work on their respective squad, although they are free to
 ## 4. New hires checklist
 
 // Work in progress ⚠️
-
-## 5. Release process
-
-The release process can be found [here](release.md).
-
-## 6. Technical documents and Proposals
-
-The technical documents and proposals can be found [here](/TechnicalDocuments/README.md).
-
-## 7. Interview process
-
-The interview process can be found [here](/Interview/README.md).
-
-## 8. Code guidelines, standards and etiquette
-
-The code guidelines, standards and etiquette can be found [here](/Standards/README.md).

--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ By definition, members work on their respective squad, although they are free to
 
 | Project name                  | Owner(s)                 | Stars        |
 |-------------------------------|--------------------------| ------------ |
-| Bento                         | Anders, David, Sergey    | [![GitHub stars](https://img.shields.io/github/stars/BabylonPartners/Bento.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/BabylonPartners/Bento/stargazers/)             |
-| DrawerKit                     | David, Wagner            |    [![GitHub stars](https://img.shields.io/github/stars/BabylonPartners/DrawerKit.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/BabylonPartners/DrawerKit/stargazers/)       |
-| ReactiveFeedback              | Anders, Sergey           |    [![GitHub stars](https://img.shields.io/github/stars/BabylonPartners/ReactiveFeedback.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/BabylonPartners/ReactiveFeedback/stargazers/)        |
+| Bento                         | Anders, David, Sergey    | [![GitHub stars](https://img.shields.io/github/stars/BabylonPartners/Bento.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/BabylonPartners/Bento/stargazers/) |
+| DrawerKit                     | David, Wagner            |    [![GitHub stars](https://img.shields.io/github/stars/BabylonPartners/DrawerKit.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/BabylonPartners/DrawerKit/stargazers/) |
+| ReactiveFeedback              | Anders, Sergey           |    [![GitHub stars](https://img.shields.io/github/stars/BabylonPartners/ReactiveFeedback.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/BabylonPartners/ReactiveFeedback/stargazers/) |
+| Style guide                   | Wagner                   |    WIP       |
 
 ## 4. New hires checklist
 

--- a/Style-guide/README.md
+++ b/Style-guide/README.md
@@ -1,51 +1,16 @@
+# Our Swift Style Guide.
+
+## Introduction
+
+This style guide is based on the [official raywenderlich.com Swift style guide](https://github.com/raywenderlich/swift-style-guide) but departs from it in several ways, to better accommodate the needs of our team. We would like to thank [Ray and his team](https://www.raywenderlich.com), and all of those who contributed to their style guide, for creating it in the first place.
+
+Our primary goals, like theirs, are clarity, consistency, and brevity but also to achieve a sufficiently stable style guide to configure a linter from. Nonetheless, it's a living document that will evolve as our needs change, as well as alongside the Swift language.
+
+### Fixing Typos
+
+Uncontroversial, non-additive changes such as misspellings, grammar or compiler errors can be fixed by simply issuing a pull request to master. The maintainer will merge the pull request or, if it is deemed "controversial", ask the contributor to open an issue so that other members of our team can participate in the discussion. We thank any and all such contributions in advance!
+
 ### This is WIP and currently in flux. The text below is not ready for review yet. Please ignore it until it's moved to a position above this message.
-
-# The Official raywenderlich.com Swift Style Guide.
-### Updated for Swift 4.2
-
-This style guide is different from others you may see, because the focus is centered on readability for print and the web. We created this style guide to keep the code in our books, tutorials, and starter kits nice and consistent — even though we have many different authors working on the books.
-
-Our overarching goals are clarity, consistency and brevity, in that order.
-
-# Contributing to the Official raywenderlich.com Swift Style Guide.
-
-This style guide is a living document that evolves with the Swift language. It is different from others you may see, because the focus is centered on readability for print and the web. We created this style guide to keep the code in our books, tutorials, and starter kits nice and consistent — even though we have many different authors working on the books.
-
-We appreciate and encourage contributions from the community that improve this document and hence the quality of tutorials we produce.  This document outlines the process for making contributions to the guide.
-
-**Note:** You are responsible for adding your name to the list of contributors should you desire.
-
-## Fixing Typos
-
-Uncontroversial, non-additive changes such as misspellings, grammar or compiler errors can be fixed by simply issuing a pull request to master. The maintainer will merge the pull request or, if it is deemed "controversial" request the contributor open an issue so that other members of the community can participate in the discussion.
-
-## Style Changes
-
-Authors at RayWenderlich.com are expected to follow all of the rules in this style guide unless special circumstances apply.  Because of this, it is important that updates happen at predictable times.  Be aware in advance that there may be a significant delay (many months) before a suggestion is ratified on the master branch.
-### Step 1: Open an Issue
-
-Open an issue on github and describe the change you would like to see or rule that you would like to have added.  You can even propose the exact change in github markdown which can be pasted into the guide.
-### Step 2: Wait for Community Feedback
-
-Wait for feedback on the issue. Even if the feedback is negative, don't close the issue too quickly.  Often times the discussion itself can be useful and give way to something even better.  Style guides are very subjective and it is important to always be respectful.  We expect participants to follow the same community guidelines as the Swift project itself outlined at [contributor-covenant.org](http://contributor-covenant.org)
-### Step 3: Wait for Maintainer Go Ahead
-
-The maintainer will decide if a change is go or no go.  This decision is not necessarily based on the feedback of the community, but will often play a role. If you believe that the maintainer is mistaken, you can appeal the decision by just asking them. At this point the maintainer will poll the RayWenderlich team leads for a final decision with RayWenderlich acting as tie breaker if required.  Apologies in advance if your style suggestion isn't accepted.  You are always welcome, however, to make your own style guide for your organization or community!
-### Step 4: Create a Pull Request on the Update branch
-
-Given the go ahead from the maintainer, create a pull request on the update branch in the repo.  There should be one of these.  If it is not clear what it is, ask the maintainer.  The current update branch is `update.`
-### Step 5: Branch Merged
-
-At this point your involvement is complete. The maintainer will merge your PR to the update branch.
-### Step 6: Update Branch Reviewed
-
-The RayWenderlich.com team has a chance to look at the final updated document before it is merged to master.  If an objection is raised, as with the appeal process, teams leads will deliberate on the final decision.
-
-### Step 7: Update Branch Merged to Master
-
-Hurray!
-
-=======
 
 ## Table of Contents
 

--- a/Style-guide/README.md
+++ b/Style-guide/README.md
@@ -1,4 +1,4 @@
-# Our Swift Style Guide.
+# Our Swift Style Guide
 
 ## Introduction
 


### PR DESCRIPTION
This first PR adds the introduction section to our swift style guide. Its secondary mission is to introduce our team to the way I'd like to conduct the creation and maintenance of this style guide.

For some time, the guide will be incomplete and in constant flux, and will not be ready to be merged into `master`. In order to organise its creation a bit better, I've created a base branch - `origin/wagner/style-guide/pre-master` - for all PRs to be merged into for some time. When we're all sufficiently happy with the result in `pre-master`, I'll open a PR to merge that into `master` and our style guide will then become official. At that point, I'll delete the `pre-master` branch and all future PRs will be addressed towards `master`.

You can see this PR's branch [here](https://github.com/Babylonpartners/ios-playbook/tree/wagner/style-guide/intro).

I will be assuming maintenance duties of the style guide for the bulk of its creation but people in the team are welcome, and encouraged, to open PRs targeting `pre-master`, if they so desire. All I ask is that people follow the plan outlined above.
 