### PR TITLE
Release 3.4.0

### DIFF
--- a/release.md
+++ b/release.md
@@ -50,5 +50,6 @@ The release process starts when the first build is provided to QA and ends when 
 
 | Version                  | Release Engineer(s)              | QA effort              | Engineering effort | Total effort |
 |--------------------------|----------------------------------| ---------------------- |--------------------|--------------|
+| 3.4.0                    | Martin Nygren                    | Automated: `06h40`<br>Manual: `32h`<br>| `UA-8385: 2h`<br>`UA8381: 4h`<br>`UA-8375 6h`<br>`UA-8374 2h`<br>`UA-8362 1h`<br>`UA-8369 2h`<br>`UA-8372 1h`<br>`MON-3631 2h`<br>`MON-3634 14h`<br>`UA-8359 13h`| Total: **3d9h40min** |
 | 3.3.0                    | David Rodrigues                  | Automated: `09h40`<br>Manual: `14h`<br>| `UA-8268: 1h`<br>`UA-8269: 1h30`<br>`UA-8252: 5h`<br>| Total: **1d7h10min** |
 | 3.2.0                    | Danilo Aliberti                  | Automated: `12h53`<br>Manual: `10h`<br>| `UA-8166: 4h`<br>`UA-8149: 2d`<br>`UA-8187: 3h`<br>| Total: **3d6h** |


### PR DESCRIPTION
Engineering effort per ticket is somewhat approximate for this release. The reason for this is that several people worked on MON-3634 and I had to do a lot of scattered work which has been recorded as work on the release ticket UA-8359.