### PR TITLE
Update to the release process

### DIFF
--- a/release.md
+++ b/release.md
@@ -15,7 +15,7 @@
 ### 2. Release step-by-step
 
 **Phase 1: Initiation**
-*It starts at the end of the sprint (typically when the new sprint starts on Monday)*
+<br/>	*It starts at the end of the sprint (typically when the new sprint starts on Monday)*
 
 1. Cut a release branch:  Create a new branch from develop and push to origin (e.g `release/3.2.0`).
 1. Bump the release version by triggering its command (eg. `/release babylon:3.2.0`) in `#ios-build` (you can run the command every time you want to upload a new build).
@@ -28,13 +28,13 @@
     1. Input the new version number.
 
 **Phase 2: Test and fix bugs**
-*It starts after the Hockey build has been delivered and it can take several cycles*
+<br/>	*It starts after the Hockey build has been delivered and it can take several cycles*
 
 1. Testers will then begin their work against the build you just created. 
 1. Any hotfix should target that branch, and you, as the release engineer, are responsible for double checking that the hotfix's PR is pointing to the release branch (instead of `develop`).
 
 **Phase 3: Submit beta builds for Hockey and App Store Connect**
-*It starts after all opened issues had been adressed and can take several cycles until final approval form QA*
+<br/>	*It starts after all opened issues had been adressed and can take several cycles until final approval form QA*
 
 1. Triger a new release build in the `#ios-build` channel
 1. Obtain the release notes form the Product Manager  and update them in the [AppStoreConnect](https://appstoreconnect.apple.com)
@@ -43,8 +43,7 @@
 1. By now, QA should be notified that there is a new version in TestFlight.
 
 **Phase 4: Submit to release in App Store Connect**
-
-*It starts after QA has signed off a particular build and can take several cycles until final approval form Apple*
+<br/>	*It starts after QA has signed off a particular build and can take several cycles until final approval form Apple*
 
 1. Make sure *Manually release this version* is selected in `Version Release`.
 2. When submitting to release, you are asked if the app uses the Advertising Identifier (IDFA). The answer is YES. You are then presented with three options please select as followed:
@@ -53,8 +52,7 @@
 	3. ✅ Attribute an action taken within this app to a previously served advertisement
 
 **Phase 5: Closure**
-
-*It starts after the app is accepted by Apple*
+<br/>	*It starts after the app is accepted by Apple*
 
 1. Tag the release and upload the binary. (If you're using the automated release command, you can find the binary in the Artifacts top section in the CI build).
 1. Merge the changes back to develop.

--- a/release.md
+++ b/release.md
@@ -14,31 +14,50 @@
 
 ### 2. Release step-by-step
 
-1. Cut a release branch when the sprint ends (typically when the new sprint starts on Monday). Create a new branch from develop and push to origin (e.g `release/3.2.0`).
-2. Bump the release version by triggering its command (eg. `/release babylon:3.2.0`) in `#ios-build` (you can run the command every time you want to upload a new build).
+**Stage 1:**
+*It starts at the end of the sprint (typically when the new sprint starts on Monday)*
+
+1. Cut a release branch:  Create a new branch from develop and push to origin (e.g `release/3.2.0`).
+1. Bump the release version by triggering its command (eg. `/release babylon:3.2.0`) in `#ios-build` (you can run the command every time you want to upload a new build).
     * This creates a test Tesflight build (try to make one as early as possible so that you can catch issues like missing/expired certificates or profiles and any other production build errors early).
-3. Trigger a hockey build from that branch using its command (eg. `/distribute release/3.2.0:babylon`) in `#ios-build`.
-4. Testers will then begin their work against the build you just created.
-5. Any hotfix should target that branch, and you, as the release engineer, are responsible for double checking that the hotfix's PR is pointing to the release branch (instead of `develop`).
-6. Create a board for the release. Use a filter to reduce its scope, eg `project = UA AND affectedVersion = "iOS 3.2.0"`.
-7. Create a new version in [AppStoreConnect](https://appstoreconnect.apple.com) (login using your own account) / My Apps 
+1. Trigger a hockey build from that branch using its command (eg. `/distribute release/3.2.0:babylon`) in `#ios-build`.
+1. Create a board for the release. Use a filter to reduce its scope, eg `project = UA AND affectedVersion = "iOS 3.2.0"`.
+1. Create and send the issue list to the Product Manager: In console run `git log --since="2018-11-26" --pretty=format:%s  > issue_list.txt` (use the date when the sprint started).
+1. Create a new version in [AppStoreConnect](https://appstoreconnect.apple.com) (login using your own account) / My Apps 
     1. On the sidebar click `+ Version or Platform` and select `iOS`.  
-    2. Input the new version number.
-    3. Add the release notes and update the release notes document.
-    4. Add your release to the release calendar.
-    5. Check if you need anything from the Marketing Team. (`#MarketingQuestions`)
-    6. Send the release notes to `#ClinicsOps`, so they have visibility on the release.
-8. Perform a quick exploratory test on the TestFlight build to make sure everything looks okay. (e.g. verifying that DigitalTwin Assets are visible and are not dropped due to Git LFS issues) ❗️ NOTE: Remember to submit compliance info for that build.
-9. By now, QA should be notified that there is a new version in TestFlight.
-10. When QA has signed off a particular build, submit the app to Apple.
-    1. Make sure *Manually release this version* is selected in `Version Release`.
-    2. When submitting to release, you are asked if the app uses the Advertising Identifier (IDFA). The answer is YES. You are then presented with three options please select as followed:
+    1. Input the new version number.
+
+**Stage 2**
+*It starts after the Hockey build has been delivered and it can take several cycles*
+
+1. Testers will then begin their work against the build you just created. 
+1. Any hotfix should target that branch, and you, as the release engineer, are responsible for double checking that the hotfix's PR is pointing to the release branch (instead of `develop`).
+
+**Stage 3**
+*It starts after all opened issues had been adressed and can also take several cycles until final approval form QA*
+
+1. Triger a new release build in the `#ios-build` channel
+1. Obtain the realease notes form the Product Manager  and update them in the [AppStoreConnect]
+1. Enable the new release version in [AppStoreConnect]. 
+1. Perform a quick exploratory test on the TestFlight build to make sure everything looks okay. (e.g. verifying that DigitalTwin Assets are visible and are not dropped due to Git LFS issues) ❗️ NOTE: Remember to submit compliance info for that build.
+1. By now, QA should be notified that there is a new version in TestFlight.
+
+**Stage 4**
+*It starts after QA has signed off a particular build*
+Submit the app to Apple in [AppStoreConnect]
+
+1. Make sure *Manually release this version* is selected in `Version Release`.
+1. When submitting to release, you are asked if the app uses the Advertising Identifier (IDFA). The answer is YES. You are then presented with three options please select as followed:
         1. 🚫 Serve advertisements within the app
-        2. ✅ Attribute this app installation to a previously served advertisement
-        3. ✅ Attribute an action taken within this app to a previously served advertisement
-11. Once the app is accepted by Apple:
-    1. Tag the release and upload the binary. (If you're using the automated release command, you can find the binary in the Artifacts top section in the CI build).
-    2. Merge the changes back to develop.
+        1. ✅ Attribute this app installation to a previously served advertisement
+        1. ✅ Attribute an action taken within this app to a previously served advertisement
+
+**Stage 5**
+*It starts after the app is accepted by Apple*
+
+1. Tag the release and upload the binary. (If you're using the automated release command, you can find the binary in the Artifacts top section in the CI build).
+1. Merge the changes back to develop.
+
 
 ### 3. Release calendar
 

--- a/release.md
+++ b/release.md
@@ -34,7 +34,7 @@
 1. Any hotfix should target that branch, and you, as the release engineer, are responsible for double checking that the hotfix's PR is pointing to the release branch (instead of `develop`).
 
 **Phase 3: Submit beta builds for Hockey and App Store Connect**
-<br/>	*It starts after all opened issues had been adressed and can take several cycles until final approval form QA*
+<br/>	*It starts after all opened issues had been adressed and can take several cycles until QA's approval*
 
 1. Triger a new release build in the `#ios-build` channel
 1. Obtain the release notes form the Product Manager  and update them in the [AppStoreConnect](https://appstoreconnect.apple.com)
@@ -43,7 +43,7 @@
 1. By now, QA should be notified that there is a new version in TestFlight.
 
 **Phase 4: Submit to release in App Store Connect**
-<br/>	*It starts after QA has signed off a particular build and can take several cycles until final approval form Apple*
+<br/>	*It starts after QA has signed off a particular build and can take several cycles until Apple's approval*
 
 1. Make sure *Manually release this version* is selected in `Version Release`.
 2. When submitting to release, you are asked if the app uses the Advertising Identifier (IDFA). The answer is YES. You are then presented with three options please select as followed:

--- a/release.md
+++ b/release.md
@@ -1,4 +1,4 @@
-
+  
 ## Release process
 
 ### 1. Release engineer as a role
@@ -14,7 +14,7 @@
 
 ### 2. Release step-by-step
 
-**Stage 1:**
+**Phase 1: Initiation**
 *It starts at the end of the sprint (typically when the new sprint starts on Monday)*
 
 1. Cut a release branch:  Create a new branch from develop and push to origin (e.g `release/3.2.0`).
@@ -27,32 +27,33 @@
     1. On the sidebar click `+ Version or Platform` and select `iOS`.  
     1. Input the new version number.
 
-**Stage 2**
+**Phase 2: Test and fix bugs**
 *It starts after the Hockey build has been delivered and it can take several cycles*
 
 1. Testers will then begin their work against the build you just created. 
 1. Any hotfix should target that branch, and you, as the release engineer, are responsible for double checking that the hotfix's PR is pointing to the release branch (instead of `develop`).
 
-**Stage 3**
-*It starts after all opened issues had been adressed and can also take several cycles until final approval form QA*
+**Phase 3: Submit beta builds for Hockey and App Store Connect**
+*It starts after all opened issues had been adressed and can take several cycles until final approval form QA*
 
 1. Triger a new release build in the `#ios-build` channel
-1. Obtain the realease notes form the Product Manager  and update them in the [AppStoreConnect]
-1. Enable the new release version in [AppStoreConnect]. 
+1. Obtain the release notes form the Product Manager  and update them in the [AppStoreConnect](https://appstoreconnect.apple.com)
+1. Enable the new release version in [AppStoreConnect](https://appstoreconnect.apple.com). 
 1. Perform a quick exploratory test on the TestFlight build to make sure everything looks okay. (e.g. verifying that DigitalTwin Assets are visible and are not dropped due to Git LFS issues) ❗️ NOTE: Remember to submit compliance info for that build.
 1. By now, QA should be notified that there is a new version in TestFlight.
 
-**Stage 4**
-*It starts after QA has signed off a particular build*
-Submit the app to Apple in [AppStoreConnect]
+**Phase 4: Submit to release in App Store Connect**
+
+*It starts after QA has signed off a particular build and can take several cycles until final approval form Apple*
 
 1. Make sure *Manually release this version* is selected in `Version Release`.
-1. When submitting to release, you are asked if the app uses the Advertising Identifier (IDFA). The answer is YES. You are then presented with three options please select as followed:
-        1. 🚫 Serve advertisements within the app
-        1. ✅ Attribute this app installation to a previously served advertisement
-        1. ✅ Attribute an action taken within this app to a previously served advertisement
+2. When submitting to release, you are asked if the app uses the Advertising Identifier (IDFA). The answer is YES. You are then presented with three options please select as followed:
+	1. 🚫 Serve advertisements within the app
+	2. ✅ Attribute this app installation to a previously served advertisement
+	3. ✅ Attribute an action taken within this app to a previously served advertisement
 
-**Stage 5**
+**Phase 5: Closure**
+
 *It starts after the app is accepted by Apple*
 
 1. Tag the release and upload the binary. (If you're using the automated release command, you can find the binary in the Artifacts top section in the CI build).

--- a/release.md
+++ b/release.md
@@ -54,7 +54,7 @@
 **Phase 5: Closure**
 <br/>	*It starts after the app is accepted by Apple and final internal approval*
 
-1. Press `Submit` in App Store Connect
+1. Press `Release this version` in App Store Connect
 1. Tag the release and upload the binary. (If you're using the automated release command, you can find the binary in the Artifacts top section in the CI build).
 1. Merge the changes back to develop.
 

--- a/release.md
+++ b/release.md
@@ -33,7 +33,7 @@
 1. Testers will then begin their work against the build you just created. 
 1. Any hotfix should target that branch, and you, as the release engineer, are responsible for double checking that the hotfix's PR is pointing to the release branch (instead of `develop`).
 
-**Phase 3: Submit beta builds for Hockey and App Store Connect**
+**Phase 3: Submit TestFlight builds to App Store Connect**
 <br/>	*It starts after all opened issues had been adressed and can take several cycles until QA's approval*
 
 1. Triger a new release build in the `#ios-build` channel
@@ -42,7 +42,7 @@
 1. Perform a quick exploratory test on the TestFlight build to make sure everything looks okay. (e.g. verifying that DigitalTwin Assets are visible and are not dropped due to Git LFS issues) ❗️ NOTE: Remember to submit compliance info for that build.
 1. By now, QA should be notified that there is a new version in TestFlight.
 
-**Phase 4: Submit to release in App Store Connect**
+**Phase 4: Submit for release in App Store Connect**
 <br/>	*It starts after QA has signed off a particular build and can take several cycles until Apple's approval*
 
 1. Make sure *Manually release this version* is selected in `Version Release`.
@@ -52,8 +52,9 @@
 	3. ✅ Attribute an action taken within this app to a previously served advertisement
 
 **Phase 5: Closure**
-<br/>	*It starts after the app is accepted by Apple*
+<br/>	*It starts after the app is accepted by Apple and final internal approval*
 
+1. Press `Submit` in App Store Connect
 1. Tag the release and upload the binary. (If you're using the automated release command, you can find the binary in the Artifacts top section in the CI build).
 1. Merge the changes back to develop.
 


### PR DESCRIPTION
- I have split the release steps in phases since the steps happen at different moments in time.
- I have added the creating of the release notes
- I have removed outdated steps: 
> Check if you need anything from the Marketing Team. (`#MarketingQuestions`) and Send the release notes to `#ClinicsOps`, so they have visibility on the release.