### PR TITLE
Post Screen Events to Analytics as Flow Side Effects.

### DIFF
--- a/TechnicalDocuments/Proposals/TrackScreenEventsAsSideEffects.md
+++ b/TechnicalDocuments/Proposals/TrackScreenEventsAsSideEffects.md
@@ -1,28 +1,197 @@
-# <Title>
+# Track Screen Events as Flow Side Effects.
 
-* Author(s): Author1, Author2
-* Review Manager: ReviewManager
+* Author: Martin Nygren
+* Review Manager: Anders Ha
 
 ## Introduction
 
-// A short explanation about this proposal's goals.
+There is a push to improve product analytics, both in terms of the technology
+stack and coverage. To increase the coverage there is an ambition to post a
+screen view event whenever a new screen is rendered. Screen event is a somewhat
+loose term but for iOS it is a reasonable default interpretation to say that a
+screen event happens when the `view` of `UIViewController` becomes visible.
 
 ## Motivation
 
-// This section should the answer the `why?`.
+Since we will have to post a lot of screen events we want it to be easy to add
+code to track them.
+
+Posting analytics events should ideally not have any impact
+on the business logic. In an ideal world it would always be possible to collect
+product analytics data without any impact on the business or user interface
+logic, reality tends to be messier but the more analytics events we can collect
+without interfering with the business logic the better it is.
+
+It might happen that we get requirements to post some extra data in addition to
+the screen name. Although there is an ambition to keep data points consistent
+and simple it cannot be guaranteed that all of them will be.
+
+Experimenting with decorating flows with side effects I have arrived at the
+conclusion that this approach makes it quite quick to add screen event tracking.
+
+Adding screen event tracking as side-effects make sure that they don't have
+any impact on the business logic.
+
+Collecting more complicated data points can be done by decorating the flow
+differently or adding a second decoration.
+
+You can check out `martin/flow-struct-experiment` if you want to have a look at
+how this would impact our codebase. Screen event tracking has been added to the
+GP @ Hand registration journeys. Things are a bit experimental, so would need
+some cleaning up but does hopefully show how it would work.
 
 ## Proposed solution
 
-// This section should the answer the `how?`.
+Creating a general side-effect that can be used to post the screen name requires
+a mechanism for reading the screen name from the view controller. Part one of
+this proposal is thus to add define a protocol `ScreenNaming`
+
+```
+public protocol ScreenNaming {
+    func screenName() -> String?
+}
+
+```
+
+with a default implementation for `UIViewController`
+
+```
+extension UIViewController: ScreenNaming {
+    @objc open func screenName() -> String? { return view.accessibilityIdentifier }
+}
+```
+
+Using the `accessibilityIdentifier` to store the screen name has been discussed
+within the team and was considered a bit risky. I do, however, feel that in
+nearly all cases it will be fine to use the same string constant for the screen
+name and the accessibility identifier.
+
+It has been discussed that we should add a default mechanism for assigning
+accessibility identifiers to Bento components. If this happens we might not want
+to use that accessibility identifier as the screen name. In my view adding this
+override to `BabylonBoxViewController` offers a convenient way to define a
+different screen name for bento style view controllers.
+
+```
+open class BabylonBoxViewController<ViewModel, Renderer>: BoxViewController<ViewModel, Renderer, BabylonAppAppearance> {
+  ...
+  @objc open override func screenName() -> String? {
+    if let name = (viewModel as? ScreenNaming)?.screenName() {
+        return name
+    } else {
+        return super.screenName()
+    }
+  }
+}
+```
+
+With a solution for defining screen names for view controllers it is now
+possible to define a generic mechanism for posting screen views to the analytics
+service.
+
+```
+enum FlowAnalyticsEvent: AnalyticsEvent {
+    case screenView(name: String)
+}
+
+extension FlowAnalyticsEvent {
+    static func screenViewTracking(
+        _ flow: Flow,
+        with tracker: AnalyticsTrackingService
+        ) -> Flow {
+
+        func trackScreenView() {
+            guard let viewController = flow.currentViewController() else { return }
+
+            if let screenName = viewController.screenName(),
+                screenName.isNotEmpty {
+                tracker.track(FlowAnalyticsEvent.screenView(name: screenName))
+            }
+        }
+
+        func decoratedPresent(_ viewController: UIViewController, _ animated: Bool, _ completion: (() -> Void)?) {
+            flow.present(viewController, animated: animated, completion: completion)
+            trackScreenView()
+        }
+
+        func decoratedReplace(_ viewController: UIViewController, _ animated: Bool) {
+            flow.replace(with: viewController, animated: animated)
+            trackScreenView()
+        }
+
+        func decoratedDismiss(animated: Bool, _ completion: (() -> Void)?) {
+            flow.dismiss(animated: animated, completion: completion)
+            trackScreenView()
+        }
+
+        return Flow(
+            presentViewController: decoratedPresent,
+            replaceViewController: decoratedReplace,
+            dismissViewController: decoratedDismiss,
+            currentViewController: flow.currentViewController)
+    }
+
+    static func screenViewTracking(_ flow: Flow) -> Flow {
+        return screenViewTracking(flow, with: Current.analyticsService)
+    }
+}
+```
+
+This example uses the `Flow` implementation that has been refactored to a struct
+that I have suggested in a previous proposal. Something similar can be done with
+the current `protocol` implementation, but to me it feels more natural to use a
+struct with function variables. Please note that `currentViewController()` is
+needed to post a screen event when a modal is dismissed or the user goes back
+in a navigation stack.
+
+Finally, to track screen view events we need to decorate the `Flow`, here is
+how to do it for the GP @ Hand Introduction journey
+
+```
+private func showNHSIntro() {
+        BabylonNavigationController { navigation, modal in
+            return builders.nhsOnboarding.make(
+                navigation: navigation |> FlowAnalyticsEvent.screenViewTracking,
+                modal: modal |> FlowAnalyticsEvent.screenViewTracking,
+                parent: self.modal,
+                root: self.modal
+            )
+        } |> modal.present
+    }
+```
+
+I added this helper function to make `|>` available.
+
+```
+static func screenViewTracking(_ flow: Flow) -> Flow {
+    return screenViewTracking(flow, with: Current.analyticsService)
+}
+```
+
+It is important to note that `Flow` instances should only be decorated at the
+point when they are created. Otherwise it can be difficult to understand if a
+`Flow` already has been or needs to be decorated.
 
 ## Impact on existing codebase
 
-// This section should explain, assuming this proposal is accepted, how much effort it would require for it to be implemented in our codebase. Other concerns should be raised, if it's a significant deviation from our stack. 
+This is were I see a major advantage with the proposed solution. Decorating a
+flow with a analytics tracking side effect when it is created is a fairly
+small change to the code that is easy to read.
+
+Amending view models or view controllers to comply with `ScreenNaming` can be
+done in extensions and thus have no impact on existing code.
 
 ## Alternatives considered
 
-// This section describes what other approaches were considered and why this one was chosen.
+Implement `viewDidAppear`, or observe `viewController.reactive.signal(for: #selector(UIViewController.viewDidAppear))`,
+and post a `FlowAnalyticsEvent.screenView(name: "BestViewControllerEver")` whenever
+it is called. In my view this approach is inferior for two reasons:
+- Less flexible. By decorating flows it is possible to change the tracking
+depending on how the screen has been reached without adding state to the view
+controller or view model.
+- Smaller amount of code re-use. Decorating flows means fewer changes to the
+codebase.
 
---- 
-* [ ] **By creating this proposal, I understand that it might not be accepted**. I also agree that, if it's accepted,
+---
+* [x] **By creating this proposal, I understand that it might not be accepted**. I also agree that, if it's accepted,
 depending on its complexity, I might be requested to give a workshop to the rest of the team. 🚀

--- a/TechnicalDocuments/Proposals/TrackScreenEventsAsSideEffects.md
+++ b/TechnicalDocuments/Proposals/TrackScreenEventsAsSideEffects.md
@@ -1,0 +1,28 @@
+# <Title>
+
+* Author(s): Author1, Author2
+* Review Manager: ReviewManager
+
+## Introduction
+
+// A short explanation about this proposal's goals.
+
+## Motivation
+
+// This section should the answer the `why?`.
+
+## Proposed solution
+
+// This section should the answer the `how?`.
+
+## Impact on existing codebase
+
+// This section should explain, assuming this proposal is accepted, how much effort it would require for it to be implemented in our codebase. Other concerns should be raised, if it's a significant deviation from our stack. 
+
+## Alternatives considered
+
+// This section describes what other approaches were considered and why this one was chosen.
+
+--- 
+* [ ] **By creating this proposal, I understand that it might not be accepted**. I also agree that, if it's accepted,
+depending on its complexity, I might be requested to give a workshop to the rest of the team. 🚀

--- a/TechnicalDocuments/Proposals/TrackScreenEventsAsSideEffects.md
+++ b/TechnicalDocuments/Proposals/TrackScreenEventsAsSideEffects.md
@@ -19,7 +19,7 @@ code to track them.
 Posting analytics events should ideally not have any impact
 on the business logic. In an ideal world it would always be possible to collect
 product analytics data without any impact on the business or user interface
-logic, reality tends to be messier but the more analytics events we can collect
+logic. The reality tends to be messier but the more analytics events we can collect
 without interfering with the business logic the better it is.
 
 It might happen that we get requirements to post some extra data in addition to
@@ -29,7 +29,7 @@ and simple it cannot be guaranteed that all of them will be.
 Experimenting with decorating flows with side effects I have arrived at the
 conclusion that this approach makes it quite quick to add screen event tracking.
 
-Adding screen event tracking as side-effects make sure that they don't have
+Adding screen event tracking as side-effects makes sure that it doesn't have
 any impact on the business logic.
 
 Collecting more complicated data points can be done by decorating the flow
@@ -74,14 +74,14 @@ different screen name for bento style view controllers.
 
 ```
 open class BabylonBoxViewController<ViewModel, Renderer>: BoxViewController<ViewModel, Renderer, BabylonAppAppearance> {
-  ...
-  @objc open override func screenName() -> String? {
-    if let name = (viewModel as? ScreenNaming)?.screenName() {
-        return name
-    } else {
-        return super.screenName()
+    ...
+    @objc open override func screenName() -> String? {
+        if let name = (viewModel as? ScreenNaming)?.screenName() {
+            return name
+        } else {
+            return super.screenName()
+        }
     }
-  }
 }
 ```
 
@@ -98,7 +98,7 @@ extension FlowAnalyticsEvent {
     static func screenViewTracking(
         _ flow: Flow,
         with tracker: AnalyticsTrackingService
-        ) -> Flow {
+    ) -> Flow {
 
         func trackScreenView() {
             guard let viewController = flow.currentViewController() else { return }
@@ -149,15 +149,15 @@ how to do it for the GP @ Hand Introduction journey
 
 ```
 private func showNHSIntro() {
-        BabylonNavigationController { navigation, modal in
-            return builders.nhsOnboarding.make(
-                navigation: navigation |> FlowAnalyticsEvent.screenViewTracking,
-                modal: modal |> FlowAnalyticsEvent.screenViewTracking,
-                parent: self.modal,
-                root: self.modal
-            )
-        } |> modal.present
-    }
+    BabylonNavigationController { navigation, modal in
+        return builders.nhsOnboarding.make(
+            navigation: navigation |> FlowAnalyticsEvent.screenViewTracking,
+            modal: modal |> FlowAnalyticsEvent.screenViewTracking,
+            parent: self.modal,
+            root: self.modal
+        )
+    } |> modal.present
+}
 ```
 
 I added this helper function to make `|>` available.

--- a/TechnicalDocuments/Proposals/TrackScreenEventsAsSideEffects.md
+++ b/TechnicalDocuments/Proposals/TrackScreenEventsAsSideEffects.md
@@ -46,7 +46,7 @@ Creating a general side-effect that can be used to post the screen name requires
 a mechanism for reading the screen name from the view controller. Part one of
 this proposal is thus to add define a protocol `ScreenNaming`
 
-```
+```swift
 public protocol ScreenNaming {
     func screenName() -> String?
 }
@@ -55,7 +55,7 @@ public protocol ScreenNaming {
 
 with a default implementation for `UIViewController`
 
-```
+```swift
 extension UIViewController: ScreenNaming {
     @objc open func screenName() -> String? { return view.accessibilityIdentifier }
 }
@@ -72,7 +72,7 @@ to use that accessibility identifier as the screen name. In my view adding this
 override to `BabylonBoxViewController` offers a convenient way to define a
 different screen name for bento style view controllers.
 
-```
+```swift
 open class BabylonBoxViewController<ViewModel, Renderer>: BoxViewController<ViewModel, Renderer, BabylonAppAppearance> {
     ...
     @objc open override func screenName() -> String? {
@@ -89,7 +89,7 @@ With a solution for defining screen names for view controllers it is now
 possible to define a generic mechanism for posting screen views to the analytics
 service.
 
-```
+```swift
 enum FlowAnalyticsEvent: AnalyticsEvent {
     case screenView(name: String)
 }
@@ -147,7 +147,7 @@ in a navigation stack.
 Finally, to track screen view events we need to decorate the `Flow`, here is
 how to do it for the GP @ Hand Introduction journey
 
-```
+```swift
 private func showNHSIntro() {
     BabylonNavigationController { navigation, modal in
         return builders.nhsOnboarding.make(
@@ -162,7 +162,7 @@ private func showNHSIntro() {
 
 I added this helper function to make `|>` available.
 
-```
+```swift
 static func screenViewTracking(_ flow: Flow) -> Flow {
     return screenViewTracking(flow, with: Current.analyticsService)
 }

--- a/TechnicalDocuments/README.md
+++ b/TechnicalDocuments/README.md
@@ -10,3 +10,4 @@ Technical Documents and Proposals 🛠
 
 * [Proposal Template](./Proposals/Template.md)
 * [Global `Current` struct to hold global dependencies](./Proposals/ControlTheWorld.md).
+* [Track Screen EVents as Flow Side Effects](./Proposals/TrackScreenEventsAsSideEffects.md)

--- a/TechnicalDocuments/README.md
+++ b/TechnicalDocuments/README.md
@@ -10,4 +10,4 @@ Technical Documents and Proposals 🛠
 
 * [Proposal Template](./Proposals/Template.md)
 * [Global `Current` struct to hold global dependencies](./Proposals/ControlTheWorld.md).
-* [Track Screen EVents as Flow Side Effects](./Proposals/TrackScreenEventsAsSideEffects.md)
+* [Track Screen Events as Flow Side Effects](./Proposals/TrackScreenEventsAsSideEffects.md)


### PR DESCRIPTION
This proposal introduces a reasonably general mechanism for posting screen events when a new screen is rendered. My design goals have been to:

- High degree of code re-use.
- Easy to add screen event tracking.
- Avoid updating business logic.

Examples for how it would work in our code base can be found in the `martin/flow-struct-experiment` branch in the main repository. 

It is important to note that even though my examples are based on `Flow` instances that have been refactored as structs it is not necessary to refactor our current `Flow` implementations for this approach to work. In my view, refactoring `Flow` to be a struct makes adding side effects easier and more intuitive. I am, however, happy to add screen event tracking as side effects to our current `Flow` implementations if consensus is to not refactor `Flow`.