### PR TITLE
Added column for relevant dates

### DIFF
--- a/release.md
+++ b/release.md
@@ -67,11 +67,11 @@ The release process starts when the first build is provided to QA and ends when 
 3. Delta between the jira ticket being open and marked as `done` or `wont fix`, for Engineering effort. (e.g. `UA-8289: 1h30`)
 4. Total effort
 
-| Version                  | Release Engineer(s)              | QA effort              | Engineering effort | Total effort | Cut-off date| Release date |
-|--------------------------|----------------------------------| ---------------------- |--------------------|--------------|
-| 3.7.0                    | Ben Henshall, David Rodrigues | Automated: `06h58m`<br>Manual: `32h`<br>| `MON-3855: 2h`<br>`MON-3857: 1h`<br>`AV-207: 1h`<br>`NRX-190: 3h`<br>`CNSMR-493: 3h`<br>`CNSMR-477: 3h`<br> | Total: **2d3h58mh** |
-| 3.6.0                    | Viorel Mihalache, Ilya Puchka | Automated: <br>Manual: <br>| `CNMSR-388`<br>`CNMSR-397`<br>`CE-146`<br>`NRX-150`<br>`CNMSR-404`<br>`NRX-149`<br>`UA-8329`<br>`UA-8431`<br>`CNMSR-365`<br>`CNMSR-324`<br>`CNMSR-340`<br>`CE-124`<br> | Total: **8d** |
-| 3.5.0                    | Wagner Truppel                   | Automated: `06h47`<br>Manual: `28h`<br>| `CNSMR-82: 1h39m`<br>| Total: **1d12h26m** |
-| 3.4.0                    | Martin Nygren                    | Automated: `06h40`<br>Manual: `32h`<br>| `UA-8385: 2h`<br>`UA8381: 4h`<br>`UA-8375 6h`<br>`UA-8374 2h`<br>`UA-8362 1h`<br>`UA-8369 2h`<br>`UA-8372 1h`<br>`MON-3631 2h`<br>`MON-3634 14h`<br>`UA-8359 13h`<br>| Total: **3d9h40min** |
-| 3.3.0                    | David Rodrigues                  | Automated: `09h40`<br>Manual: `14h`<br>| `UA-8268: 1h`<br>`UA-8269: 1h30`<br>`UA-8252: 5h`<br>| Total: **1d7h10min** |
-| 3.2.0                    | Danilo Aliberti                  | Automated: `12h53`<br>Manual: `10h`<br>| `UA-8166: 4h`<br>`UA-8149: 2d`<br>`UA-8187: 3h`<br>| Total: **3d6h** |
+| Version | Release Engineer(s)  | QA effort   | Engineering effort          | Total effort  | Cut-off date  | Release date  |
+|---------|----------------------|-------------|-----------------------------|---------------|---------------|---------------|
+| 3.7.0                    | Ben Henshall, David Rodrigues | Automated: `06h58m`<br>Manual: `32h`<br>| `MON-3855: 2h`<br>`MON-3857: 1h`<br>`AV-207: 1h`<br>`NRX-190: 3h`<br>`CNSMR-493: 3h`<br>`CNSMR-477: 3h`<br> | Total: **2d3h58mh** | | |
+| 3.6.0                    | Viorel Mihalache, Ilya Puchka | Automated: <br>Manual: <br>| `CNMSR-388`<br>`CNMSR-397`<br>`CE-146`<br>`NRX-150`<br>`CNMSR-404`<br>`NRX-149`<br>`UA-8329`<br>`UA-8431`<br>`CNMSR-365`<br>`CNMSR-324`<br>`CNMSR-340`<br>`CE-124`<br> | Total: **8d** | | |
+| 3.5.0                    | Wagner Truppel                   | Automated: `06h47`<br>Manual: `28h`<br>| `CNSMR-82: 1h39m`<br>| Total: **1d12h26m** | | |
+| 3.4.0                    | Martin Nygren                    | Automated: `06h40`<br>Manual: `32h`<br>| `UA-8385: 2h`<br>`UA8381: 4h`<br>`UA-8375 6h`<br>`UA-8374 2h`<br>`UA-8362 1h`<br>`UA-8369 2h`<br>`UA-8372 1h`<br>`MON-3631 2h`<br>`MON-3634 14h`<br>`UA-8359 13h`<br>| Total: **3d9h40min** | | |
+| 3.3.0                    | David Rodrigues                  | Automated: `09h40`<br>Manual: `14h`<br>| `UA-8268: 1h`<br>`UA-8269: 1h30`<br>`UA-8252: 5h`<br>| Total: **1d7h10min** | | |
+| 3.2.0                    | Danilo Aliberti                  | Automated: `12h53`<br>Manual: `10h`<br>| `UA-8166: 4h`<br>`UA-8149: 2d`<br>`UA-8187: 3h`<br>| Total: **3d6h** | | |

--- a/release.md
+++ b/release.md
@@ -67,7 +67,7 @@ The release process starts when the first build is provided to QA and ends when 
 3. Delta between the jira ticket being open and marked as `done` or `wont fix`, for Engineering effort. (e.g. `UA-8289: 1h30`)
 4. Total effort
 
-| Version                  | Release Engineer(s)              | QA effort              | Engineering effort | Total effort |
+| Version                  | Release Engineer(s)              | QA effort              | Engineering effort | Total effort | Cut-off date| Release date |
 |--------------------------|----------------------------------| ---------------------- |--------------------|--------------|
 | 3.7.0                    | Ben Henshall, David Rodrigues | Automated: `06h58m`<br>Manual: `32h`<br>| `MON-3855: 2h`<br>`MON-3857: 1h`<br>`AV-207: 1h`<br>`NRX-190: 3h`<br>`CNSMR-493: 3h`<br>`CNSMR-477: 3h`<br> | Total: **2d3h58mh** |
 | 3.6.0                    | Viorel Mihalache, Ilya Puchka | Automated: <br>Manual: <br>| `CNMSR-388`<br>`CNMSR-397`<br>`CE-146`<br>`NRX-150`<br>`CNMSR-404`<br>`NRX-149`<br>`UA-8329`<br>`UA-8431`<br>`CNMSR-365`<br>`CNMSR-324`<br>`CNMSR-340`<br>`CE-124`<br> | Total: **8d** |


### PR DESCRIPTION
Currently there is no indication for how long the actual release process took from the moment the branch is cut-of until the moment the app was released to the store (including apple review time)
