### PR TITLE
move checkboxes to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/proposal.md
+++ b/.github/PULL_REQUEST_TEMPLATE/proposal.md
@@ -1,0 +1,4 @@
+* [ ] I will send a meeting invitation, using this [template](Template_Proposal_Meeting_Invitation.MD), scheduled for 2 weeks after this proposal is made, so an agreement can be reached.
+* [ ] **By creating this proposal, I understand that it might not be accepted**. I also agree that, if it's accepted,
+depending on its complexity, I might be requested to give a workshop to the rest of the team. 🚀
+

--- a/TechnicalDocuments/Proposals/Template_Proposal.md
+++ b/TechnicalDocuments/Proposals/Template_Proposal.md
@@ -23,7 +23,3 @@
 
 // This section describes what other approaches were considered and why this one was chosen.
 
----
-* [ ] I will send a meeting invitation, using this [template](Template_Proposal_Meeting_Invitation.MD), scheduled for 2 weeks after this proposal is made, so an agreement can be reached.
-* [ ] **By creating this proposal, I understand that it might not be accepted**. I also agree that, if it's accepted,
-depending on its complexity, I might be requested to give a workshop to the rest of the team. 🚀


### PR DESCRIPTION
It occurred to me that these checkboxes may be better in PR template rather than proposal document itself.