### PR TITLE
[nit] Fixes a quotes mistake - typo and tab formatting

### DIFF
--- a/TechnicalDocuments/Lokalise.md
+++ b/TechnicalDocuments/Lokalise.md
@@ -7,7 +7,7 @@ Create an account using your `@babylonhealth.com` email address and request acce
 
 To update strings in the app the following `Fastlane` lanes can be used:
 ```
-bundle exec fastlane lokalise_pull         // download all projects
+bundle exec fastlane lokalise_pull             // download all projects
 bundle exec fastlane lokalise_pull_babylon     //download the main Babylon
 
 // these download the other apps projects - they are subsets that populates the files `TargetSpecificLocalizable`

--- a/TechnicalDocuments/Lokalise.md
+++ b/TechnicalDocuments/Lokalise.md
@@ -13,7 +13,7 @@ bundle exec fastlane lokalise_pull_babylon     //download the main Babylon
 // these download the other apps projects - they are subsets that populates the files `TargetSpecificLocalizable`
 bundle exec fastlane lokalise_pull_telus
 bundle exec fastlane lokalise_pull_nhs111
-bundle exec fastlane lokalise_pull_bupa```
+bundle exec fastlane lokalise_pull_bupa
 ```
 
 To add/modify keys/values, when you are in a `Project` on the website, you can use `⌘K` or click the blue button `Add key`…


### PR DESCRIPTION
there was excess of ``` quotes on the end of the block. 