### PR TITLE
Remove new hires checklists from frontpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ At Babylon, we firmly believe that **transparency** is a core value that should 
 1. [Who's in the team](#1-whos-in-the-team)
 2. [Which squad each individual belongs to, and its availability](#2-which-squad-each-individual-belongs-to-and-its-availability)
 3. [OSS-maintained projects](#3-oss-maintained-projects)
-4. [New hires checklist](#4-new-hires-checklist)
+4. [New hires checklist](/TechnicalDocuments/NewHiresCheckList.md)
 5. [Release process](release.md)
 6. [Technical documents and Proposals](/TechnicalDocuments/README.md)
 7. [Interview process](/Interview/README.md)
@@ -70,38 +70,3 @@ By definition, members work on their respective squad, although they are free to
 | DrawerKit                     | David, Wagner            |    [![GitHub stars](https://img.shields.io/github/stars/BabylonPartners/DrawerKit.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/BabylonPartners/DrawerKit/stargazers/) |
 | ReactiveFeedback              | Anders, Sergey           |    [![GitHub stars](https://img.shields.io/github/stars/BabylonPartners/ReactiveFeedback.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/BabylonPartners/ReactiveFeedback/stargazers/) |
 | Style guide                   |                    |    WIP       |
-
-## 4. New hires checklist
-
-Prior to starting, make sure you have a Babylon GitHub account and that you have access to the following repositories:
-
-- [babylon-ios](https://github.com/Babylonpartners/babylon-ios)
-- [ios-charts](https://github.com/Babylonpartners/ios-charts)
-- [ios-private-podspecs](https://github.com/Babylonpartners/ios-private-podspecs)
-- [ios-build-distribution](https://github.com/Babylonpartners/ios-build-distribution)
-- [ios-fastlane-match](https://github.com/Babylonpartners/ios-fastlane-match)
-
-Here's how to get the iOS project up and running.
-
-1. Clone the iOS repository: https://github.com/Babylonpartners/babylon-ios
-1. Set up Git LFS and pull, according to these instructions: https://github.com/Babylonpartners/babylon-ios/wiki/How-to-install-Git-LFS
-1. Globally configure Git to use SSH instead of HTTPS: https://ricostacruz.com/til/github-always-ssh
-     ```
-     git config --global url."git@github.com:".insteadOf "https://github.com/"
-     ```
-1. Run `bundle install`
-1. Run `pod install`
-1. Open `Babylon.xcworkspace` in Xcode (there may be several warnings; they can be ignored)
-1. Configure the Xcode **Text Editing -> Editing** preferences as follows:
-     - Automatically trim trailing whitespace
-     - Including whitespace-only lines
-     - Default line endings: macOS / Unix (LF)
-     - Convert existing files on save
-1. Configure the Xcode **Text Editing -> Indentation** preferences as follows:
-     - Prefer indent using: Spaces
-     - Tab width: 4 spaces
-     - Indent width: 4 spaces
-     - Tab key: Indents in leading whitespace
-1. Make sure the device selected for testing is iPhone 5s
-
-<img src="iphone-5s.png" height="101" width="388" alt="iPhone 5s" />

--- a/TechnicalDocuments/NewHiresCheckList.md
+++ b/TechnicalDocuments/NewHiresCheckList.md
@@ -1,0 +1,34 @@
+# New Hires Checklist
+
+Prior to starting, make sure you have a Babylon GitHub account and that you have access to the following repositories:
+
+- [babylon-ios](https://github.com/Babylonpartners/babylon-ios)
+- [ios-charts](https://github.com/Babylonpartners/ios-charts)
+- [ios-private-podspecs](https://github.com/Babylonpartners/ios-private-podspecs)
+- [ios-build-distribution](https://github.com/Babylonpartners/ios-build-distribution)
+- [ios-fastlane-match](https://github.com/Babylonpartners/ios-fastlane-match)
+
+Here's how to get the iOS project up and running.
+
+1. Clone the iOS repository: https://github.com/Babylonpartners/babylon-ios
+1. Set up Git LFS and pull, according to these instructions: https://github.com/Babylonpartners/babylon-ios/wiki/How-to-install-Git-LFS
+1. Globally configure Git to use SSH instead of HTTPS: https://ricostacruz.com/til/github-always-ssh
+```
+git config --global url."git@github.com:".insteadOf "https://github.com/"
+```
+1. Run `bundle install`
+1. Run `pod install`
+1. Open `Babylon.xcworkspace` in Xcode (there may be several warnings; they can be ignored)
+1. Configure the Xcode **Text Editing -> Editing** preferences as follows:
+- Automatically trim trailing whitespace
+- Including whitespace-only lines
+- Default line endings: macOS / Unix (LF)
+- Convert existing files on save
+1. Configure the Xcode **Text Editing -> Indentation** preferences as follows:
+- Prefer indent using: Spaces
+- Tab width: 4 spaces
+- Indent width: 4 spaces
+- Tab key: Indents in leading whitespace
+1. Make sure the device selected for testing is iPhone 5s
+
+<img src="iphone-5s.png" height="101" width="388" alt="iPhone 5s" />


### PR DESCRIPTION
It's an useful doc but it's not that important that it needs to be displayed on the frontpage.