### PR TITLE
Add jira ticket for ForgotPasswordViewModel

### DIFF
--- a/TechnicalDocuments/TechnicalDebt.md
+++ b/TechnicalDocuments/TechnicalDebt.md
@@ -52,7 +52,7 @@ Porting these view controllers to Bento will also make it easier to apply an app
 | AddAddressViewModel | |
 | PrivacySettingsViewModel | |
 | ChooseCountryViewModel | |
-| ForgotPasswordViewModel | |
+| ForgotPasswordViewModel | CNSMR-904 |
 | NotificationsViewModel | |
 | ProfileViewModel | |
 | SignInViewModel | |


### PR DESCRIPTION
`ForgotPasswordViewModel` is using `Forms` and it should be ported to `Bento`.

This PR adds the relevant jira ticket.