### PR TITLE
Add public channels for squads (if there are any)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ By definition, members work on their respective squad, although they are free to
 |-------------------------------|----------------------------------| ------------ | -------------------- |
 | SDK                           | Viorel                           |    1/3       | [#sdk_squad](https://babylonhealth.slack.com/archives/CC5JNDGJJ) |
 | Consultation                  | Ilya                             |    1/1       |
-| Booking                       | Witold                           |    1/1       |
+| Booking                       | Witold                           |    1/1       | [#prescription-squad](https://babylonhealth.slack.com/archives/C88TCM9JB) |
 | Prescriptions                 | Adam                             |    1/1       |
 | Healthcheck                   | Ben, Catarina                    |    2/3       | [#healthcheck_tribe](https://babylonhealth.slack.com/archives/C7995CX3R) |
 | Native/Core                   | Giorgos, Jason, Martin           |    3/6       | [#nativeapps_public](https://babylonhealth.slack.com/archives/CE5P8LRNH) |

--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ At Babylon, we firmly believe that **transparency** is a core value that should 
 By definition, members work on their respective squad, although they are free to work in different squads if the work load justifies it.
 
 
-| Squad Name                    | Members                          | Availability |
-|-------------------------------|----------------------------------| ------------ |
-| SDK                           | Viorel                           |    1/3       |
+| Squad Name                    | Members                          | Availability | Public slack channel |
+|-------------------------------|----------------------------------| ------------ | -------------------- |
+| SDK                           | Viorel                           |    1/3       | [#sdk_squad](https://babylonhealth.slack.com/archives/CC5JNDGJJ) |
 | Consultation                  | Ilya                             |    1/1       |
 | Booking                       | Witold                           |    1/1       |
 | Prescriptions                 | Adam                             |    1/1       |
-| Healthcheck                   | Ben, Catarina                    |    2/3       |
+| Healthcheck                   | Ben, Catarina                    |    2/3       | [#healthcheck_tribe](https://babylonhealth.slack.com/archives/C7995CX3R) |
 | Native/Core                   | Giorgos, Jason, Martin           |    3/6       |
 | Professional Services         | Danilo                           |    1/3       |
-| GP at Hand                    | Diego                            |    1/1       |
+| Enrolment and Integrity       | Diego                            |    1/1       | [#ei-squad](https://babylonhealth.slack.com/archives/CGR4D5NKX) |
 | Core Experience               | Sergey                           |    1/2       |
-| Health Management             | David, Joao                      |    2/2       |
-| Monitor                       | Anders                           |    1/2       |
-| Triage UI                     | Michael                          |    1/2       |
+| Health Management             | David, Joao                      |    2/2       | [#health-mgmt-public](https://babylonhealth.slack.com/archives/CCNHJUXLH) |
+| Monitor                       | Anders                           |    1/2       | [https://babylonhealth.slack.com/archives/CE37S5W9Z](https://babylonhealth.slack.com/archives/CE37S5W9Z) |
+| Triage UI                     | Michael                          |    1/2       | [#squad_triage_ui](https://babylonhealth.slack.com/archives/CE6H6SLRX) |
 
 
 ## 3. OSS-maintained projects

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ By definition, members work on their respective squad, although they are free to
 | Squad Name                    | Members                          | Availability | Public slack channel |
 |-------------------------------|----------------------------------| ------------ | -------------------- |
 | SDK                           | Viorel                           |    1/3       | [#sdk_squad](https://babylonhealth.slack.com/archives/CC5JNDGJJ) |
-| Consultation                  | Ilya                             |    1/1       |
-| Booking                       | Witold                           |    1/1       | [#prescription-squad](https://babylonhealth.slack.com/archives/C88TCM9JB) |
-| Prescriptions                 | Adam                             |    1/1       |
+| Consultation                  | Ilya                             |    1/1       | |
+| Booking                       | Witold                           |    1/1       |  |
+| Prescriptions                 | Adam                             |    1/1       | [#prescription-squad](https://babylonhealth.slack.com/archives/C88TCM9JB) |
 | Healthcheck                   | Ben, Catarina                    |    2/3       | [#healthcheck_tribe](https://babylonhealth.slack.com/archives/C7995CX3R) |
 | Native/Core                   | Giorgos, Jason, Martin           |    3/6       | [#nativeapps_public](https://babylonhealth.slack.com/archives/CE5P8LRNH) |
 | Professional Services         | Danilo                           |    1/3       | [#telus](https://babylonhealth.slack.com/archives/CAJ7YQZ5Z) |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ By definition, members work on their respective squad, although they are free to
 | Booking                       | Witold                           |    1/1       |
 | Prescriptions                 | Adam                             |    1/1       |
 | Healthcheck                   | Ben, Catarina                    |    2/3       | [#healthcheck_tribe](https://babylonhealth.slack.com/archives/C7995CX3R) |
-| Native/Core                   | Giorgos, Jason, Martin           |    3/6       |
+| Native/Core                   | Giorgos, Jason, Martin           |    3/6       | [#nativeapps_public](https://babylonhealth.slack.com/archives/CE5P8LRNH) |
 | Professional Services         | Danilo                           |    1/3       | [#telus](https://babylonhealth.slack.com/archives/CAJ7YQZ5Z) |
 | Enrolment and Integrity       | Diego                            |    1/1       | [#ei-squad](https://babylonhealth.slack.com/archives/CGR4D5NKX) |
 | Core Experience               | Sergey                           |    1/2       | [#core-experience](https://babylonhealth.slack.com/archives/CCSE8JLK0) |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ By definition, members work on their respective squad, although they are free to
 | Enrolment and Integrity       | Diego                            |    1/1       | [#ei-squad](https://babylonhealth.slack.com/archives/CGR4D5NKX) |
 | Core Experience               | Sergey                           |    1/2       |
 | Health Management             | David, Joao                      |    2/2       | [#health-mgmt-public](https://babylonhealth.slack.com/archives/CCNHJUXLH) |
-| Monitor                       | Anders                           |    1/2       | [https://babylonhealth.slack.com/archives/CE37S5W9Z](https://babylonhealth.slack.com/archives/CE37S5W9Z) |
+| Monitor                       | Anders                           |    1/2       | [#patient-metrics-team](https://babylonhealth.slack.com/archives/CE37S5W9Z) |
 | Triage UI                     | Michael                          |    1/2       | [#squad_triage_ui](https://babylonhealth.slack.com/archives/CE6H6SLRX) |
 
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ By definition, members work on their respective squad, although they are free to
 | Prescriptions                 | Adam                             |    1/1       |
 | Healthcheck                   | Ben, Catarina                    |    2/3       | [#healthcheck_tribe](https://babylonhealth.slack.com/archives/C7995CX3R) |
 | Native/Core                   | Giorgos, Jason, Martin           |    3/6       |
-| Professional Services         | Danilo                           |    1/3       |
+| Professional Services         | Danilo                           |    1/3       | [#telus](https://babylonhealth.slack.com/archives/CAJ7YQZ5Z) |
 | Enrolment and Integrity       | Diego                            |    1/1       | [#ei-squad](https://babylonhealth.slack.com/archives/CGR4D5NKX) |
-| Core Experience               | Sergey                           |    1/2       |
+| Core Experience               | Sergey                           |    1/2       | [#core-experience](https://babylonhealth.slack.com/archives/CCSE8JLK0) |
 | Health Management             | David, Joao                      |    2/2       | [#health-mgmt-public](https://babylonhealth.slack.com/archives/CCNHJUXLH) |
 | Monitor                       | Anders                           |    1/2       | [#patient-metrics-team](https://babylonhealth.slack.com/archives/CE37S5W9Z) |
 | Triage UI                     | Michael                          |    1/2       | [#squad_triage_ui](https://babylonhealth.slack.com/archives/CE6H6SLRX) |


### PR DESCRIPTION
As per title. This way we can better redirect information requests.