### PR TITLE
Tweak Void for function outputs rule

### DIFF
--- a/Cookbook/Style-guide/README.md
+++ b/Cookbook/Style-guide/README.md
@@ -410,12 +410,14 @@ func reticulateSplines(
 }
 ```
 
-Don't use `(Void)` to represent the lack of an input; simply use `()`. Use `Void` instead of `()` for closure and function outputs.
+Don't use `(Void)` to represent the lack of an input; simply use `()`.
+Use `Void` instead of `()` for closure outputs.
+Don't use `Void` for function outputs as it is redundant.
 
 **Preferred**:
 
 ```swift
-func updateConstraints() -> Void {
+func updateConstraints() {
   // magic happens here
 }
 


### PR DESCRIPTION
This is to follow SwiftLint's `redundant_void_return` rule, which I think makes a lot of sense. Implementation here https://github.com/Babylonpartners/babylon-ios/tree/Diego/CNSMR-xxx-void-as-return (no PR yet).