### PR TITLE
Automate most of the new-hire onboarding checklist

### DIFF
--- a/Cookbook/Technical-Documents/NewHiresCheckList.md
+++ b/Cookbook/Technical-Documents/NewHiresCheckList.md
@@ -1,6 +1,6 @@
 # New Hires Checklist
 
-## GitHub access
+## GitHub Access
 
 Prior to starting, make sure you have a Babylon GitHub account and that you have access to the following repositories:
 
@@ -42,53 +42,32 @@ As an iOS Engineer, you should be in the following Slack channels:
 
 Make sure you also join your Tribe/Squad's Slack channels.
 
-## Setup your development environment
+## Install prerequisites
 
-Here's how to get the iOS project up and running.
+  - Xcode + its command-line tools
+  - [Homebrew](https://brew.sh/)
+  - Ruby 2.4
 
-1. Globally configure Git to use SSH instead of HTTPS:
-     ```
-     git config --global url."git@github.com:".insteadOf "https://github.com/"
-     ```
-     
+If you don't have Ruby or a version manager, you can use RVM to set up Ruby 2.4:
+
+```
+\curl -sSL https://get.rvm.io | bash -s stable
+source ~/.rvm/scripts/rvm
+rvm install 2.4
+rvm use 2.4
+```
+
+## Setup Guide
+
+Most of the work to get the iOS project up and running is automated inside a
+shell script. Here's how to get the iOS project up and running:
+
 1. [Generate](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) & add the SSH key to your [GitHub account](https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account)
 
-1. Install Homebrew if you don't already have it installed:    
-     ```
-     /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-     ```
-
-1. Setup Git LFS:
-     ```
-     brew install git-lfs
-     git lfs install
-     ```
-
-1. Clone the iOS repository: https://github.com/Babylonpartners/babylon-ios  
-*Make sure you've already done the `Setup Git LFS` step before cloning the project.*
-     ```
-     git clone git@github.com:Babylonpartners/babylon-ios.git
-     ```
-
-1. Get our latest Xcode templates by running `./Templates/install_xcode_templates.sh`
-
-1. Install RVM and Ruby version 2.4
-     ```
-     \curl -sSL https://get.rvm.io | bash -s stable
-     source ~/.rvm/scripts/rvm
-     rvm install 2.4
-     rvm use 2.4
-     ```
-1. Install Ruby gems (do this in the root of the project directory):
-     ```
-     bundle install
-     ```
-1. Install Cocoapods pods:
-     ```
-     gem install bundler
-     bundle exec pod install
-     ```
-      It can be useful to create a command line alias for `pod` to `bundle exec pod` so that you are guaranteed to always be running the correct version of Cocoapods.
+1. Run the `ios-onboarding` Bash script inside the `scripts` directory of this
+   repo. It requires a `CODE_DIRECTORY` argument which is the parent directory
+   where you want the `babylon-ios` repo cloned into. See the documentation
+   inside the script for example usage.
 
 1. Open `Babylon.xcworkspace` in Xcode (there may be several warnings; they can be ignored). You can use `xed .` on the command line at the root of the project to open the workspace.
 
@@ -108,13 +87,15 @@ Here's how to get the iOS project up and running.
 
 ## What's next?
 
+1. It can be useful to create a command line alias for `pod` to `bundle exec pod` so that you are guaranteed to always be running the correct version of Cocoapods.
+
 1. [Install additional tools and ask access for the various services we use](ToolsAndServices.md).
 
 1. Add yourself to the team list in the [playbook](https://github.com/Babylonpartners/ios-playbook) by making your first PR 😉
 
 1. Add shared `iOS Developers` calendar to your calendar on Outlook
 
-1. Don't hesitate to create a PR with an update to this `NewHiresCheckList` if you have spotted something is missing here.
+1. Don't hesitate to create a PR with an update to this `NewHiresCheckList` or the `ios-onboarding` script if you have spotted something is missing or could be improved.
 
-1. Ask your team lead to be invited to any upcoming/recurring meetings (like PR parties or sprint retros).  
+1. Ask your team lead to be invited to any upcoming/recurring meetings (like PR parties or sprint retros).
    You'll also be invited to the `#newbabylonians` private Slack channel after your induction; feel free to ask there to be invited to recurring company meetings too, like the weekly company standups

--- a/scripts/ios-onboarding
+++ b/scripts/ios-onboarding
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Set up repo and related dependencies for iOS development at Babylon.  This
+# script will echo every command that it's running, for clarity.
+#
+# This script is reasonably idempotent.
+#
+# Required Arguments:
+#
+#   CODE_DIRECTORY
+#   the absolute path of the directory into which you would like to clone the
+#   babylon-ios repo (do not include a trailing slash)
+#
+# To use this script, set CODE_DIRECTORY and invoke it. For example, to clone
+# the babylon-ios repo into a directory underneath /Users/me/code, run:
+#
+#   $ CODE_DIRECTORY=/Users/me/code scripts/ios-onboarding
+#
+# See the "New Hires Checklist" in the ios-playbook repo for more details.
+
+set -eo pipefail  # exit immediately when any command fails
+set -o nounset    # treat unset variables as an error
+set -x            # echo every command before running it
+
+target_directory="${CODE_DIRECTORY}/babylon-ios"
+
+# Globally configure Git to use SSH instead of HTTPS.
+git config --global url."git@github.com:".insteadOf "https://github.com/"
+
+# Set up Git LFS.
+brew install git-lfs
+git lfs install
+
+# Clone the iOS repository into the given code directory, if needed.
+if [[ ! -d "${target_directory}" ]]; then
+  git clone git@github.com:Babylonpartners/babylon-ios.git "${target_directory}"
+fi
+cd "${target_directory}"
+
+# Get the latest Xcode templates.
+./Templates/install_xcode_templates.sh
+
+# Install project dependencies (Ruby gems and Cocoapods pods).
+gem install bundler -v '~> 1.0'
+bundle install
+bundle exec pod install
+
+set +x
+echo
+echo "The babylon-ios project is now ready for local development on your system."
+echo "It has been set up in: ${target_directory}"
+echo "Run 'xed .' inside that directory to get started!"
+echo


### PR DESCRIPTION
  - Pull most commands into a single shell script that only requires one
    argument (a target directory to clone the repo into).

  - Update the instructions to avoid duplicating installation
    instructions for third-party tools -- instead, link directly to
    their documentation so we don't have to worry about keeping the
    specific installation instructions up-to-date.