### PR TITLE
Enable multiline_parameter & multiline_arguments rules in SwiftLint

### DIFF
--- a/Cookbook/Proposals/MultilineArgumentsBracket_SwiftLint_rule.md
+++ b/Cookbook/Proposals/MultilineArgumentsBracket_SwiftLint_rule.md
@@ -7,7 +7,26 @@
 The motivation to create this proposal to not waste the time to fix violations of a SwfitLint's rule which we maybe wouldn't like to have, considering all pros & cons.
 
 ## Motivation
-In our [StyleGuide](https://github.com/Babylonpartners/ios-playbook/tree/master/Cookbook/Style-guide#function-declarations) we have a section about multiline arguments & parameters. Multiline function declaration or function calls should have their brackets in separate lines e.g:
+In our [StyleGuide](https://github.com/Babylonpartners/ios-playbook/tree/master/Cookbook/Style-guide#function-declarations) we have a section about multiline arguments & parameters. Multiline function declaration or function calls should have their brackets in separate lines.To reduce our time spent on fixing such nits we can use SwiftLint to warns us about such issues.
+
+## Proposed solution
+Turn on the following SwiftLint rules:
+```
+- multiline_arguments
+- multiline_arguments_brackets
+- multiline_parameters
+- multiline_parameters_brackets
+```
+The documentation of these rules, with examples, can be found [here](https://github.com/realm/SwiftLint/blob/master/Rules.md#multiline-arguments).
+
+## Impact on existing codebase
+After adding these rules to our codebase, Xcode reports about 2500+ violations. That would need to be solved before marging to develop. More than the half of the work can be automated by using SwiftFormat to automatically format files. After running [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) there are around ~900 issues to be fixed manually.
+
+In my opinion the impact on the codebase will be very positive, however it will also add few changes which are not defined in our style guide. I think it's acceptable price to make it possible to resolve nits quicker which would decrease a time when a PR is open.
+
+However, the given set of rules goes a step further. `multiline_arguments_brackets` rule makes it possible achieve what we want — which is, having a trailing bracket at a function call in the new line. However, this rule **always** requires to put the trailing bracket `)` in a newline if the function takes more than just one line to be invoked. Even if it's only one argument. What I mean by that is explained below.
+
+The following example is the style we want to have based on the StyleGuide:
 ```swift
 func reticulateSplines(
   spline: [Double],
@@ -25,26 +44,9 @@ let success = reticulateSplines(
   comment: "normalize the display"
 )
 ```
-To reduce our time spent on fixing such nits we can use SwiftLint to warns us about such issues.
+This is all about having parameters/arguments in seprate lines when we define/call multiple parameters/arguments functions.
 
-## Proposed solution
-Turn on the following SwiftLint rules:
-```
-- multiline_arguments
-- multiline_arguments_brackets
-- multiline_parameters
-- multiline_parameters_brackets
-```
-The documentation of these rules, with examples, can be found [here](https://github.com/realm/SwiftLint/blob/master/Rules.md#multiline-arguments).
-
-## Impact on existing codebase
-After adding these rules to our codebase, Xcode reports about 2500+ violations. That would need to be solved before marging to develop. More than the half of the work can be automated by using SwiftFormat to automatically format files. After running [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) there are around ~900 issues to be fixed manually.
-
-In my opinion the impact on the codebase will be very positive, however it will also add few changes which are not defined in our style guide. I think it's acceptable price to make it possible to resolve nits quicker which would decrease a time when a PR is open.
-
-However, the given set of rules goes a step further. `multiline_arguments_brackets` rule makes it possible achieve what we want — which is, having a trailing bracket at a function call in the new line `)`. However, this rule **always** requires to put the trailing bracket `)` in a newline if the function takes more than just one line to be invoked. Even if it's only one argument.
-
-These are a few examples of pieces of code that trigger the rule and how can this be fixed. Keep in mind that this is a list of changes which are not defined in the `Function Definition` or `Function Call` sections of the [StyleGuide](https://github.com/Babylonpartners/ios-playbook/tree/master/Cookbook/Style-guide#function-declarations), and so the style guide will need to be updated accordingly.
+This time, the following examples show what else triggers the rule and how can this be fixed. Keep in mind that this is a list of changes which are not defined in the `Function Definition` or `Function Call` sections of the [StyleGuide](https://github.com/Babylonpartners/ios-playbook/tree/master/Cookbook/Style-guide#function-declarations), and so the style guide will need to be updated accordingly. I would say sometimes the code before a fix is more readable than after SwiftLint's fix.
 
  1. **Trailing closure argument**:
 ```swift
@@ -106,6 +108,9 @@ return accessible.access(
 ```
 
 More examples of changes that would need to be added can be found in [the sample PR](https://github.com/Babylonpartners/babylon-ios/pull/7246/files) I've created against develop. It's not ready to be merged. It's a result of running [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) & couple of manual changes.
+
+## The question to be asked when reviwing this proposal
+Is it worth to have an automatic function parameters/arguments nits checking for the price of few additional changes in our style? 
  
 ## Alternatives considered
 

--- a/Cookbook/Proposals/MultilineArgumentsBracket_SwiftLint_rule.md
+++ b/Cookbook/Proposals/MultilineArgumentsBracket_SwiftLint_rule.md
@@ -38,7 +38,7 @@ Turn on following SwiftLint rules:
 The documentation with samples what particular rule does can be found [here](https://github.com/realm/SwiftLint/blob/master/Rules.md#multiline-arguments).
 
 ## Impact on existing codebase
-When adding the rule to our codebase, Xcode reports about 2500+ violations of the rule. That would need to be solved. Around half of the work can be automated by using SwiftFormat to automatically format files. After running SwiftFormat there's around ~900 issues to be fixed manually.
+When adding the rule to our codebase, Xcode reports about 2500+ violations of the rule. That would need to be solved. Around half of the work can be automated by using SwiftFormat to automatically format files. After running [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) there's around ~900 issues to be fixed manually.
 
 In my opinion the impact on the codebase will be very positive, however it will also add few changes which are not defined in our style guide. I think it's acceptable price to make it possible to resolve nits quicker which would decrease a time when a PR is open.
 
@@ -53,7 +53,7 @@ AppsFlyerTracker.shared()?.continue(userActivity, restorationHandler: { restorin
 })
 ```
 The fix:
-```
+```swift
 AppsFlyerTracker.shared()?.continue(
     userActivity,
     restorationHandler: { restoring in
@@ -105,7 +105,7 @@ return accessible.access(
 )
 ```
 
-More examples of what changes that would bring can be find in [the sample PR](https://github.com/Babylonpartners/babylon-ios/pull/7246/files) I've created against develop.
+More examples of changes that would need to be added can be found in [the sample PR](https://github.com/Babylonpartners/babylon-ios/pull/7246/files) I've created against develop. It's not ready to be merged. It's a result of running [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) & couple of manual changes.
  
 ## Alternatives considered
 

--- a/Cookbook/Proposals/MultilineArgumentsBracket_SwiftLint_rule.md
+++ b/Cookbook/Proposals/MultilineArgumentsBracket_SwiftLint_rule.md
@@ -4,10 +4,10 @@
 * Review Manager: Diego Petrucci
 
 ## Introduction
-The motivation to create this proposal to not waste the time to fix violations of a SwfitLint's rule which we maybe wouldn't like to have, considering all pros & cons.
+The motivation to create this proposal is to not waste time fixing violations of a SwfitLint rule which we maybe wouldn't like to have, considering all pros & cons.
 
 ## Motivation
-In our [StyleGuide](https://github.com/Babylonpartners/ios-playbook/tree/master/Cookbook/Style-guide#function-declarations) we have a section about multiline arguments & parameters. Multiline function declaration or function calls should have their brackets in separate lines.To reduce our time spent on fixing such nits we can use SwiftLint to warns us about such issues.
+In our [StyleGuide](https://github.com/Babylonpartners/ios-playbook/tree/master/Cookbook/Style-guide#function-declarations) we have a section about multiline arguments & parameters. Multiline function declaration or function calls should have their brackets in separate lines. To reduce our time spent on fixing such nits we can use SwiftLint to warns us about such issues.
 
 ## Proposed solution
 Turn on the following SwiftLint rules:
@@ -20,7 +20,7 @@ Turn on the following SwiftLint rules:
 The documentation of these rules, with examples, can be found [here](https://github.com/realm/SwiftLint/blob/master/Rules.md#multiline-arguments).
 
 ## Impact on existing codebase
-After adding these rules to our codebase, Xcode reports about 2500+ violations. That would need to be solved before marging to develop. More than the half of the work can be automated by using SwiftFormat to automatically format files. After running [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) there are around ~900 issues to be fixed manually.
+After adding these rules to our codebase, Xcode reports about 2500+ violations. That would need to be solved before merging to develop. More than the half of the work can be automated by using SwiftFormat to automatically format files. After running [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) there are around ~900 issues to be fixed manually.
 
 In my opinion the impact on the codebase will be very positive, however it will also add few changes which are not defined in our style guide. I think it's acceptable price to make it possible to resolve nits quicker which would decrease a time when a PR is open.
 
@@ -44,9 +44,9 @@ let success = reticulateSplines(
   comment: "normalize the display"
 )
 ```
-This is all about having parameters/arguments in seprate lines when we define/call multiple parameters/arguments functions.
+This is all about having parameters/arguments in separate lines when we define/call multiple parameters/arguments functions.
 
-This time, the following examples show what else triggers the rule and how can this be fixed. Keep in mind that this is a list of changes which are not defined in the `Function Definition` or `Function Call` sections of the [StyleGuide](https://github.com/Babylonpartners/ios-playbook/tree/master/Cookbook/Style-guide#function-declarations), and so the style guide will need to be updated accordingly. I would say sometimes the code before a fix is more readable than after SwiftLint's fix.
+This time, the following examples show what else triggers the rule and how this can be fixed. Keep in mind that this is a list of changes which are not defined in the `Function Definition` or `Function Call` sections of the [StyleGuide](https://github.com/Babylonpartners/ios-playbook/tree/master/Cookbook/Style-guide#function-declarations), and so the style guide will need to be updated accordingly. I would say sometimes the code before a fix is more readable than after SwiftLint's fix.
 
  1. **Trailing closure argument**:
 ```swift
@@ -109,7 +109,7 @@ return accessible.access(
 
 More examples of changes that would need to be added can be found in [the sample PR](https://github.com/Babylonpartners/babylon-ios/pull/7246/files) I've created against develop. It's not ready to be merged. It's a result of running [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) & couple of manual changes.
 
-## The question to be asked when reviwing this proposal
+## The question to be asked when reviewing this proposal
 Is it worth to have an automatic function parameters/arguments nits checking for the price of few additional changes in our style? 
  
 ## Alternatives considered

--- a/Cookbook/Proposals/MultilineArgumentsBracket_SwiftLint_rule.md
+++ b/Cookbook/Proposals/MultilineArgumentsBracket_SwiftLint_rule.md
@@ -28,23 +28,23 @@ let success = reticulateSplines(
 To reduce our time spent on fixing such nits we can use SwiftLint to warns us about such issues.
 
 ## Proposed solution
-Turn on following SwiftLint rules:
+Turn on the following SwiftLint rules:
 ```
 - multiline_arguments
 - multiline_arguments_brackets
 - multiline_parameters
 - multiline_parameters_brackets
 ```
-The documentation with samples what particular rule does can be found [here](https://github.com/realm/SwiftLint/blob/master/Rules.md#multiline-arguments).
+The documentation of these rules, with examples, can be found [here](https://github.com/realm/SwiftLint/blob/master/Rules.md#multiline-arguments).
 
 ## Impact on existing codebase
-After adding rules to our codebase, Xcode reports about 2500+ violations of them. That would need to be solved before marging to develop. More than the half of the work can be automated by using SwiftFormat to automatically format files. After running [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) there's around ~900 issues to be fixed manually.
+After adding these rules to our codebase, Xcode reports about 2500+ violations. That would need to be solved before marging to develop. More than the half of the work can be automated by using SwiftFormat to automatically format files. After running [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) there are around ~900 issues to be fixed manually.
 
 In my opinion the impact on the codebase will be very positive, however it will also add few changes which are not defined in our style guide. I think it's acceptable price to make it possible to resolve nits quicker which would decrease a time when a PR is open.
 
-However, the given set of rules goes a step further. `multiline_arguments_brackets` rule makes it possible achieve what we want, which is, having a trailing bracket at a function call in the new line `)`. However, this rule **always** requires to put trailing bracket `)` in a newline if the function takes more than just one line to be invoked. Even if it's only one argument.
+However, the given set of rules goes a step further. `multiline_arguments_brackets` rule makes it possible achieve what we want — which is, having a trailing bracket at a function call in the new line `)`. However, this rule **always** requires to put the trailing bracket `)` in a newline if the function takes more than just one line to be invoked. Even if it's only one argument.
 
-Few examples what pieces of the code trigger the rule and how can this be fixed. Keep in mind this is a list of changes which are not defined in the `Function Definition` or `Function Call` sections of the [StyleGuide](https://github.com/Babylonpartners/ios-playbook/tree/master/Cookbook/Style-guide#function-declarations).
+These are a few examples of pieces of code that trigger the rule and how can this be fixed. Keep in mind that this is a list of changes which are not defined in the `Function Definition` or `Function Call` sections of the [StyleGuide](https://github.com/Babylonpartners/ios-playbook/tree/master/Cookbook/Style-guide#function-declarations), and so the style guide will need to be updated accordingly.
 
  1. **Trailing closure argument**:
 ```swift
@@ -111,11 +111,11 @@ More examples of changes that would need to be added can be found in [the sample
 
 There are few alternatives:
 
-- drop the one of those four rules (the `multiline_arguments_brackets`). However dropping this rule will allow to have such a function call, which is against our style guide:
+- Drop the one of those four rules — the `multiline_arguments_brackets`. However, doing so will allow to have such a function call, which is against our style guide:
 ```swift
 makeAutoFillFormAction(with: formProperties,
     genders: genders,
     continueAction: continueAction)
 ```
 
-- write custom rule to swiftlint which would satisfy our needs. We could consider creating a PR to the SwiftLint. This however will be more time consuming to do.
+- Write a custom rule to swiftlint which would satisfy our needs. We could consider creating a PR to the SwiftLint repo. This however will be more time consuming to do.

--- a/Cookbook/Proposals/MultilineArgumentsBracket_SwiftLint_rule.md
+++ b/Cookbook/Proposals/MultilineArgumentsBracket_SwiftLint_rule.md
@@ -44,7 +44,7 @@ In my opinion the impact on the codebase will be very positive, however it will 
 
 However, the given set of rules goes a step further. `multiline_arguments_brackets` rule makes it possible achieve what we want, which is, having a trailing bracket at a function call in the new line `)`. However, this rule **always** requires to put trailing bracket `)` in a newline if the function takes more than just one line to be invoked. Even if it's only one argument.
 
-Few example what pieces of the code trigger the rule and how can this be fixed:
+Few examples what pieces of the code trigger the rule and how can this be fixed. Keep in mind this is a list of changes which are not defined in the `Function Definition` or `Function Call` sections of the [StyleGuide](https://github.com/Babylonpartners/ios-playbook/tree/master/Cookbook/Style-guide#function-declarations).
 
  1. **Trailing closure argument**:
 ```swift

--- a/Cookbook/Proposals/MultilineArgumentsBracket_SwiftLint_rule.md
+++ b/Cookbook/Proposals/MultilineArgumentsBracket_SwiftLint_rule.md
@@ -38,7 +38,7 @@ Turn on following SwiftLint rules:
 The documentation with samples what particular rule does can be found [here](https://github.com/realm/SwiftLint/blob/master/Rules.md#multiline-arguments).
 
 ## Impact on existing codebase
-When adding the rule to our codebase, Xcode reports about 2500+ violations of the rule. That would need to be solved. Around half of the work can be automated by using SwiftFormat to automatically format files. After running [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) there's around ~900 issues to be fixed manually.
+After adding rules to our codebase, Xcode reports about 2500+ violations of them. That would need to be solved before marging to develop. More than the half of the work can be automated by using SwiftFormat to automatically format files. After running [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) there's around ~900 issues to be fixed manually.
 
 In my opinion the impact on the codebase will be very positive, however it will also add few changes which are not defined in our style guide. I think it's acceptable price to make it possible to resolve nits quicker which would decrease a time when a PR is open.
 


### PR DESCRIPTION
I've started to enabling the set of rules described in proposal. However, those rules affects more than our StyleGuide says so I want to first look if majority of us wants to have this rule enabled with all its pros & cons