### PR TITLE
Fix broken link in technical documents

### DIFF
--- a/Cookbook/README.md
+++ b/Cookbook/README.md
@@ -35,7 +35,7 @@ iOS Cookbook 👩‍🍳
 
 * [Strings and Localisation](./Technical-Documents/Lokalise.md)
 * [Outstanding Technical Debt and Legacy Code](./Technical-Documents/TechnicalDebt.md)
-    * [BBAddAdditionalPatientInformationViewControllerV2](./Technical-Documents/TechnicalDebt.md)
+    * [BBAddAdditionalPatientInformationViewControllerV2](./Technical-Documents/BBAddAdditionalPatientInformationViewControllerV2.md)
 
 * [✏️] What is Gherkin (the When / Given / Then/ And formatting used by QA) and how can i determine it's correctness in QA PRs
 * [Fastlane Match](./Technical-Documents/FastlaneMatch.md)


### PR DESCRIPTION
link points to technical documents, not the specific page it is intended to.