### PR TITLE
Style guide: add note about extension access qualifiers because of new SwiftLint rule.

### DIFF
--- a/Cookbook/Style-guide/README.md
+++ b/Cookbook/Style-guide/README.md
@@ -762,7 +762,7 @@ Only explicitly use `open`, `public`, and `internal` when you require a full acc
 
 Use access control as the leading property specifier. The only things that should come before access control are the `static` specifier or attributes such as `@IBAction`, `@IBOutlet` and `@discardableResult`.
 
-Use `private`, `fileprivate`, `internal`, and `public` visibility qualifiers on each function implemented in an extension, rather than have a single qualifier for the entire extension.
+Use `private`, `fileprivate`, `internal`, and `public` access-level modifiers on each function implemented in an extension, rather than having a single access-level modifier for the entire extension.
 
 **Preferred**:
 ```swift

--- a/Cookbook/Style-guide/README.md
+++ b/Cookbook/Style-guide/README.md
@@ -762,8 +762,6 @@ Only explicitly use `open`, `public`, and `internal` when you require a full acc
 
 Use access control as the leading property specifier. The only things that should come before access control are the `static` specifier or attributes such as `@IBAction`, `@IBOutlet` and `@discardableResult`.
 
-Use `private`, `fileprivate`, `internal`, and `public` access-level modifiers on each function implemented in an extension, rather than having a single access-level modifier for the entire extension.
-
 **Preferred**:
 ```swift
 private let message = "Great Scott!"
@@ -779,6 +777,22 @@ fileprivate let message = "Great Scott!"
 
 class TimeMachine {
   lazy dynamic private var fluxCapacitor = FluxCapacitor()
+}
+```
+
+Use `private`, `fileprivate`, `internal`, and `public` access-level modifiers on each function implemented in an extension, rather than having a single access-level modifier for the entire extension.
+
+**Preferred**:
+```swift
+extension TimeMachine {
+  fileprivate var fluxCapacitor = FluxCapacitor()
+}
+```
+
+**Not Preferred**:
+```swift
+fileprivate extension TimeMachine {
+  var fluxCapacitor = FluxCapacitor()
 }
 ```
 

--- a/Cookbook/Style-guide/README.md
+++ b/Cookbook/Style-guide/README.md
@@ -205,8 +205,6 @@ Since the compiler does not allow you to re-declare protocol conformance in a de
 
 For UIKit view controllers, consider grouping lifecycle, custom accessors, and IBAction in separate class extensions.
 
-Use `private`, `fileprivate`, `internal`, and `public` visibility qualifiers on each function implemented in a protocol extension, rather than have a single qualifier for the entire protocol extension.
-
 ### Unused Code
 
 Unused (dead) code, including Xcode template code and placeholder comments should be removed.
@@ -763,6 +761,8 @@ Using `private` and `fileprivate` appropriately adds clarity and promotes encaps
 Only explicitly use `open`, `public`, and `internal` when you require a full access control specification.
 
 Use access control as the leading property specifier. The only things that should come before access control are the `static` specifier or attributes such as `@IBAction`, `@IBOutlet` and `@discardableResult`.
+
+Use `private`, `fileprivate`, `internal`, and `public` visibility qualifiers on each function implemented in an extension, rather than have a single qualifier for the entire extension.
 
 **Preferred**:
 ```swift

--- a/Cookbook/Style-guide/README.md
+++ b/Cookbook/Style-guide/README.md
@@ -780,7 +780,7 @@ class TimeMachine {
 }
 ```
 
-Use `private`, `fileprivate`, `internal`, and `public` access-level modifiers on each function implemented in an extension, rather than having a single access-level modifier for the entire extension.
+Use `private`, `fileprivate`, `internal`, and `public` access-level modifiers on each property, type or function declared in an `extension`, rather than having a single access-level modifier for the entire `extension`.
 
 **Preferred**:
 ```swift


### PR DESCRIPTION
As promised, given [the new SwiftLint rule](https://github.com/Babylonpartners/babylon-ios/pull/7399).