### PR TITLE
Style guide: encourage use of `MARK`s when they help improve code organisation

### DIFF
--- a/Cookbook/Style-guide/README.md
+++ b/Cookbook/Style-guide/README.md
@@ -173,7 +173,7 @@ let colour = "red"
 
 ## Code Organization
 
-Use extensions to organize your code into logical blocks of functionality. Do not use `// MARK: -` comments.
+Use extensions to organize your code into logical blocks of functionality. Add `MARK`s if they help with it.
 
 ### Protocol Conformance
 


### PR DESCRIPTION
People like their `MARK`s