### PR TITLE
Extend our approach to comments

### DIFF
--- a/Cookbook/Proposals/Comments.md
+++ b/Cookbook/Proposals/Comments.md
@@ -221,4 +221,3 @@ It doesn't have any impact on existing codebase as this is about extending a rul
 ## Alternatives considered
 1. Leave the StyleGuide as it is, aka. reject this proposal.
 2. Modify the list of good comments. Maybe we don't agree on everything in this proposal but we like part of it.
-3. We can also extend this proposal to define our approach to `MARK`. Currentely, `MARK` is not covered in the Style Guide neither in this proposal.

--- a/Cookbook/Proposals/Comments.md
+++ b/Cookbook/Proposals/Comments.md
@@ -5,7 +5,7 @@
 
 ## Introduction
 
-I'd like to extend what our style guide says on comments. Right now it says very little and I think that can be improved extended. Currently it says:
+I'd like to extend what our style guide says on comments. Right now it says very little and I think that can be improved extended. Currently, it says:
 
 
 > Comments
@@ -19,11 +19,11 @@ I'd like to extend what our style guide says on comments. Right now it says very
 
 ## Motivation
 
-I think we sometimes overuse comments. The reason for this our StyleGuide doesn't say much on comments and this leads us to having different opinions whether a comment is worth to be added or not in our Pull Requests.
+I think we sometimes overuse comments. The reason for this our StyleGuide doesn't say much on comments and this leads us to have different opinions whether a comment is worth to be added or not in our Pull Requests.
 
-I think comments are rather bad than good because of 2 following reasons: 
+I think comments are rather bad than good because of the 2 following reasons: 
 
-1. Comments eventually starts to lie.
+1. Comments eventually start to lie.
 2. Usage of comments gives a false-positive feeling to the author that the code is readable.
 
 Look at this comment:
@@ -40,7 +40,7 @@ public enum ConsultationMethod: String {
     case faceToFace = "face to face"
 }
 ```
-At the beginning the `ConsultationMethod` had indeed 2 cases. This may be trivial here without big consequences however that not always a case and a lie may cost us many of hours.
+At the beginning, the `ConsultationMethod` had indeed 2 cases. This may be trivial here without big consequences however that not always a case and a lie may cost us many of hours.
 
 "Cross-files" comments are even more dangerous to become a lie at some point. Consider the following comment:
 ```
@@ -52,7 +52,7 @@ public func makeBookingConfirmation(
     dismiss: @escaping () -> Void
 ) -> UIViewController 
 ```
-Such a comment is a leak of information from another file into Builder. Builder doesn't know how BusinessController works. A change in a BusinessController can change the behaviour of given  screen, while there won't be a need to even enter to the builder to find out there is a comment. At the end, comment stays there, unchanged.
+Such a comment is a leak of information from another file into Builder. Builder doesn't know how BusinessController works. A change in a BusinessController can change the behavior of given screen, while there won't be a need to even enter the builder to find out there is a comment. In the end, comment stays there, unchanged.
 
 In our Pull Requests I've seen sometimes unnecessary comments
 ```swift
@@ -93,13 +93,13 @@ extension AppointmentDTO {
 ## Proposed solution
 
 ### Our approach 
-The most important thing is to improve definition of our approach to comments as currently it isn't said clearly. Moreover, it would be nice to have a common way how we comment our code when we are forced to add them. 
+The most important thing is to improve the definition of our approach to comments as currently it isn't said clearly. Moreover, it would be nice to have a common way how we comment our code when we are forced to add them. 
 
 In my opinion, our approach should insist on writing always a **self-documented code**. It should be our goal. However, writing self-documented code **doesn't** mean we shouldn't use comments. It means, that commenting our code is a **necessary evil**:
 
 > The proper use of comments is to compensate for our failure to express ourself in code. Note that I used the word failure. I meant it. Comments are always failures. We must have them because we cannot always figure out how to express ourselves without them, but their use is not a cause for celebration.
-	// Robert C. Martin - "Clean Code"
-	
+    // Robert C. Martin - "Clean Code"
+    
 I think that adding the above section to our style guide would make it clear what's our approach to comments.
 
 ### What is a good comment?
@@ -109,56 +109,56 @@ To make our StyleGuide more verbose we can also add a list of what kind of comme
 **Good comments**:
 
 - **TODO comments**
-	This already have a good definition of our approach in the StyleGuide and I think we are fine with that approach.
+    This already has a good definition of our approach in the StyleGuide and I think we are fine with that approach.
 - **Doc headers for public API**
-	Good documentation helps consumers of the SDK to understand what the code does. However, I don't know if it's worth to add a comment to every public function/field, even if a comment is just a repetition. Following comment doesn't add any value (unless it's needed by a doc generation tool if we use any):
-	```swift
-	 /// Supported biometric types
-	 public var supportedBiometry: BiometryType
-	```
+    Good documentation helps consumers of the SDK to understand what the code does. However, I don't know if it's worth to add a comment to every public function/field, even if a comment is just a repetition. The following comment doesn't add any value (unless it's needed by a doc generation tool if we use any):
+    ```swift
+     /// Supported biometric types
+     public var supportedBiometry: BiometryType
+    ```
 - **Explanation of Intent/Clarification**
-	It's a kind of comment when a developer try to explain what he's trying to achieve when code is not verbose enough. Example: Math code, sometimes parsing.
+    It's a kind of comment when a developer tries to explain what he's trying to achieve when a code is not verbose enough. Example: Math code, sometimes parsing.
 - **Warning of Consequences**
-	If we had a test which takes an hour to run, it would be nice to have a comment warning about it.
+    If we had a test which takes an hour to run, it would be nice to have a comment warning about it.
 - **Amplification**
-	Sometimes some piece of a code seem to be less important than it really is. In such cases, it's worth to mark it.
+    Sometimes some piece of code seems to be less important than it really is. In such cases, it's worth to mark it.
 - **Reference to external sources**
-	For example, ISO 639 for country codes.
+    For example, ISO 639 for country codes.
 
 The above list is what defines a good comment. **However**, we still have to remember that **every** comment **is our failure** to name our code better. If someone gives you a good hint how to remove a comment without sacrificing readability **we should go for it**.
 
 ### How can we replace a comment?
-In case of a **what** comments usually it is very easy to replace a comment. Usually it's all about taking what comment says and create a variable or function with such a name.
+In case of a **what** comments usually it is very easy to replace a comment. Usually, it's all about taking what comment says and create a variable or function with such a name.
 
 
 ### How do we comment?
-Even with the proposed approach we will be forced to comment our code at some point. I would like to propose a way of doing it. The biggest difficulty for me when I read a comment (especially a long one, explaining "why") is to understand to what scope the comment refers to. I think that we should always try to export commented code into a separate method/class and put the comment as a header to this method.
+Even with the proposed approach, we will be forced to comment our code at some point. I would like to propose a way of doing it. The biggest difficulty for me when I read a comment (especially a long one, explaining "why") is to understand to what scope the comment refers to. I think that we should always try to export commented code into a separate method/class and put the comment as a header to this method.
 
-The above solution have 2 benefits:
+The above solution has 2 benefits:
 
 1. It's visible to what part of a code comment refers.
-2. It improves readability for a developer who doesn't need to know why particular piece of code is written. Sometimes, during debugging for example, what you need to know is **what** happens, not **why**.
+2. It improves readability for a developer who doesn't need to know why a particular piece of code is written. Sometimes, during debugging for example, what you need to know is **what** happens, not **why**.
 
-To illustrate point `2.`. If there is an UIKit bug, with dismissing a modal screen which is ugly but works just fine, all we care about is the fact that the code has been dismissed. During a debuting we now we can go just further without a need to understand how `dissmissing` is handled.
+To illustrate point `2.`. If there is an UIKit bug, with dismissing a modal screen which is ugly but works just fine, all we care about is the fact that the code has been dismissed. During a debuting we now we can go just further without a need to understand how `dismissing` is handled.
 
 This shows what is a good comment:
 ```swift
-		viewModel.state.signal
-			.observe(on: UIScheduler())
-			.observeValues { state in
-					let drawerState: DrawerState
-					switch state.status {
-							case .searching:
-		            drawerState = .fullyExpanded
-	            case .loading:
+        viewModel.state.signal
+            .observe(on: UIScheduler())
+            .observeValues { state in
+                    let drawerState: DrawerState
+                    switch state.status {
+                            case .searching:
+                    drawerState = .fullyExpanded
+                case .loading:
                 drawerState = .partiallyExpanded
-	            case let .loaded(places):
+                case let .loaded(places):
                 drawerState = places.isEmpty.isFalse
                  ? .partiallyExpanded
                  : .collapsed
-	            case .failed(.noPlaces):
+                case .failed(.noPlaces):
                  drawerState = .partiallyExpanded
-		          default:
+                  default:
                  drawerState = (state.suggestions != nil)
                  ? .partiallyExpanded
                  : .collapsed
@@ -208,14 +208,14 @@ This shows what is a good comment:
 // and not through the self.drawerPresentationController.
 // We can as well consider making this a default behaviour in DrawerKit
 private func setDrawerState(_ drawerState: DrawerState) {
-	drawerFlow.setDrawerState(drawerState)
+    drawerFlow.setDrawerState(drawerState)
 }
  ```
  
 
 
 ## Impact on existing codebase
-It doesn't have any impact on existing codebase as this is about extending a rule in our StyleGuide. What will change is during code reviews we may have more suggestions how to replace a comment with a code.
+It doesn't have any impact on existing codebase as this is about extending a rule in our StyleGuide. What will change is during code reviews we may have more suggestions on how to replace a comment with a code.
 
 
 ## Alternatives considered

--- a/Cookbook/Proposals/Comments.md
+++ b/Cookbook/Proposals/Comments.md
@@ -94,7 +94,7 @@ extension AppointmentDTO {
 ### Our approach 
 The most important thing is to improve the definition of our approach to comments as currently it isn't clearly defined. Moreover, it would be nice to have a common way of commenting our code when we are forced to do so. 
 
-In my opinion, our approach should insist on writing always a **self-documented code**. It should be our goal. However, writing self-documented code **doesn't** mean we shouldn't use comments. Commenting our code is, at times, a **necessary evil**:
+In my opinion, our approach should insist on writing always a **self-documented code**. It should be our goal. However, writing self-documented code **doesn't** mean we shouldn't use comments. Commenting our code is a **necessary evil**:
 
 > The proper use of comments is to compensate for our failure to express ourself in code. Note that I used the word failure. I meant it. Comments are always failures. We must have them because we cannot always figure out how to express ourselves without them, but their use is not a cause for celebration.
     // Robert C. Martin - "Clean Code"

--- a/Cookbook/Proposals/Comments.md
+++ b/Cookbook/Proposals/Comments.md
@@ -23,7 +23,7 @@ I think we sometimes overuse comments. The reason for this our StyleGuide doesn'
 
 I think comments are rather bad than good because of the 2 following reasons: 
 
-1. Comments eventually start to lie.
+1. Comments eventually start to lie since the code frequently gets updated but comments remain unchanged
 2. Usage of comments gives a false-positive feeling to the author that the code is readable.
 
 Look at this comment:
@@ -42,7 +42,7 @@ public enum ConsultationMethod: String {
 ```
 At the beginning, the `ConsultationMethod` had indeed 2 cases. This may be trivial here without big consequences however that not always a case and a lie may cost us many of hours.
 
-"Cross-files" comments are even more dangerous to become a lie at some point. Consider the following comment:
+"Cross-files" comments are even more likely of becoming lies at any given point. Consider the following comment:
 ```
 /// Make the booking confirmation screen. The created screen would always refetch
 /// the appointment from the backend.
@@ -73,12 +73,11 @@ extension AppointmentDTO {
     }
 }
 ```
-Can be simplified without any lose in understanding what the code represents to:
+Can be simplified without any loss in understanding what the code represents to:
 
 ```swift
 extension AppointmentDTO {
     public enum State: String, Codable {
-        /// waiting for payment
         case waitingForPayment = "pending"
         /// timeout == 10 min
         case paymentTimedOut = "timed_out"
@@ -93,9 +92,9 @@ extension AppointmentDTO {
 ## Proposed solution
 
 ### Our approach 
-The most important thing is to improve the definition of our approach to comments as currently it isn't said clearly. Moreover, it would be nice to have a common way how we comment our code when we are forced to add them. 
+The most important thing is to improve the definition of our approach to comments as currently it isn't clearly defined. Moreover, it would be nice to have a common way of commenting our code when we are forced to do so. 
 
-In my opinion, our approach should insist on writing always a **self-documented code**. It should be our goal. However, writing self-documented code **doesn't** mean we shouldn't use comments. It means, that commenting our code is a **necessary evil**:
+In my opinion, our approach should insist on writing always a **self-documented code**. It should be our goal. However, writing self-documented code **doesn't** mean we shouldn't use comments. Commenting our code is, at times, a **necessary evil**:
 
 > The proper use of comments is to compensate for our failure to express ourself in code. Note that I used the word failure. I meant it. Comments are always failures. We must have them because we cannot always figure out how to express ourselves without them, but their use is not a cause for celebration.
     // Robert C. Martin - "Clean Code"
@@ -109,15 +108,15 @@ To make our StyleGuide more verbose we can also add a list of what kind of comme
 **Good comments**:
 
 - **TODO comments**
-    This already has a good definition of our approach in the StyleGuide and I think we are fine with that approach.
+    This already has a good definition of our approach in the StyleGuide and I think we are fine with that approach. Don't forget to add JIRA's ticket number, if applicable.
 - **Doc headers for public API**
-    Good documentation helps consumers of the SDK to understand what the code does. However, I don't know if it's worth to add a comment to every public function/field, even if a comment is just a repetition. The following comment doesn't add any value (unless it's needed by a doc generation tool if we use any):
+    Good documentation helps consumers of the SDK understand what the code does. However, I don't know if it's worth adding a comment to every public function/field, even if a comment is just a repetition. The following comment doesn't add any value (unless it's needed by a doc generation tool if we use any):
     ```swift
      /// Supported biometric types
      public var supportedBiometry: BiometryType
     ```
 - **Explanation of Intent/Clarification**
-    It's a kind of comment when a developer tries to explain what he's trying to achieve when a code is not verbose enough. Example: Math code, sometimes parsing.
+    It's a kind of comment when a developer tries to explain what they're trying to achieve when a code is not verbose enough. Example: Math code, sometimes parsing.
 - **Warning of Consequences**
     If we had a test which takes an hour to run, it would be nice to have a comment warning about it.
 - **Amplification**
@@ -128,7 +127,7 @@ To make our StyleGuide more verbose we can also add a list of what kind of comme
 The above list is what defines a good comment. **However**, we still have to remember that **every** comment **is our failure** to name our code better. If someone gives you a good hint how to remove a comment without sacrificing readability **we should go for it**.
 
 ### How can we replace a comment?
-In case of a **what** comments usually it is very easy to replace a comment. Usually, it's all about taking what comment says and create a variable or function with such a name.
+In case of a **what** comment it is usually very easy to replace it by taking what the comment says and create a variable or function with such a name.
 
 
 ### How do we comment?
@@ -136,10 +135,10 @@ Even with the proposed approach, we will be forced to comment our code at some p
 
 The above solution has 2 benefits:
 
-1. It's visible to what part of a code comment refers.
+1. Clearly defines what part of a code comment refers to.
 2. It improves readability for a developer who doesn't need to know why a particular piece of code is written. Sometimes, during debugging for example, what you need to know is **what** happens, not **why**.
 
-To illustrate point `2.`. If there is an UIKit bug, with dismissing a modal screen which is ugly but works just fine, all we care about is the fact that the code has been dismissed. During a debuting we now we can go just further without a need to understand how `dismissing` is handled.
+To illustrate point `2.`. If there is an UIKit bug, with dismissing a modal screen which is ugly but works just fine, all we care about is the fact that the code has been dismissed. During debugging we now we can go just further without a need to understand how `dismissing` is handled.
 
 This shows what is a good comment:
 ```swift

--- a/Cookbook/Proposals/Comments.md
+++ b/Cookbook/Proposals/Comments.md
@@ -1,0 +1,138 @@
+# Comments
+
+* Author(s): Adam Borek
+* Review Manager: TBA
+
+## Introduction
+
+I'd like to extend what our style guide says on comments. Right now it says very little and I think that can be improved extended. Currently it says:
+
+
+> Comments
+
+> In the very rare occasions when they are needed, use comments to explain why a particular piece of code does something. Comments must be kept up-to-date, or altogether deleted. Never write comments that tell what the code does.
+
+> Avoid block comments inline with code, as the code should be as self-documenting as possible. Exception: This does not apply to those comments used to generate documentation.
+
+> Avoid the use of C-style comments (/* ... */). Prefer the use of double- or triple-slash.
+
+
+## Motivation
+
+I think we sometimes overuse comments. Because our StyleGuide doesn't say much on comments, we have different opinions whether a comment is worth to be added or not.
+
+I think comments are rather bad than good because of 2 following reasons: 
+
+1. Comments eventually starts to lie.
+2. Usage of comments gives a false-positive feeling to the author that the code is readable.
+
+Look at this comment:
+```swift
+/// consultation method, will be either 'phone' or 'video'
+public let consultationMethod: ConsultationMethod
+```
+
+Few lines below there's the enum declaration:
+```swift
+public enum ConsultationMethod: String {
+    case phone
+    case video
+    case faceToFace = "face to face"
+}
+```
+At the beginning the `ConsultationMethod` had indeed 2 cases. This may be trivial here without big consequences however that not always a case and a lie may cost us many of hours.
+
+In our Pull Requests I've seen sometimes unnecessary
+```swift
+extension AppointmentDTO {
+    public enum State: String, Codable {
+        /// waiting for payment
+        case pending
+        /// user failed to pay for appoitment withing 10 min after the booking
+        case timedOut = "timed_out"
+        /// canceled by user or doctor
+        case cancelled
+        /// paid by user
+        case paid
+        /// doctor finished adding notes on the portal
+        case completed
+        /// patient did not answer the doctor's call
+        case noShow = "no_show"
+    }
+}
+```
+Can be simplified without any lose in understanding what the code represents to:
+
+```swift
+extension AppointmentDTO {
+    public enum State: String, Codable {
+        /// waiting for payment
+        case waitingForPayment = "pending"
+        /// timeout == 10 min
+        case paymentTimedOut = "timed_out"
+        case cancelledByUserOrDoctor = "cancelled"
+        case paidByUser = "paid"
+        case doctorFinishedAddingNotesOnThePortal = "completed"
+        case patientDidntAnswerTheCall = "no_show"
+    }
+}
+```
+
+Moreover, commented code is not only longer but it is also fragile to become a lie at some point. When a comment contain an information from other scope (other file) in our codebase. When a developer changes something when particular action is used, he may even don't think he should change the comment as he won't see it until he enters the file. Will he enter the file? Sometimes there's no such a need.
+
+## Proposed solution
+
+### Our approach 
+The most important thing is to define our approach to comments as currently it isn't said clearly. Moreover, it would be nice to have a common way how we comment our code when we are forced to add them. 
+
+In my opinion, our approach should insist on writing always a **self-documented code**. It should be our goal. However, writing self-documented code **doesn't** mean we shouldn't use comments. It means, that commenting our code is a **necessary evil**:
+
+> The proper use of comments is to compensate for our failure to express ourself in code. Note that I used the word failure. I meant it. Comments are always failures. We must have them because we cannot always figure out how to express ourselves without them, but their use is not a cause for celebration.
+	// Robert C. Martin - "Clean Code"
+	
+I think that adding the above section to our style guide would make it clear what's our approach to comments.
+
+### What is a good comment?
+
+To make our StyleGuide be more verbose we can also add a list of what kind of comments we think are "good".
+
+**Good comments**:
+
+- **Doc headers for public API**
+- **TODO comments**
+- **Explanation of Intent/Clarification**
+	It's a kind of comment when a developer try to explain what he's trying to achieve when code is not verbose enough. Example: Math code, sometimes parsing.
+- **Warning of Consequences**
+	If we had a test which takes an hour to run, it would be nice to have a comment warning about it.
+- **Amplification**
+	Sometimes some piece of a code seem to be less important than it really is. In such cases, it's worth to mark it.
+- **Reference to external sources**
+	For example, ISO 639 for country codes.
+
+The above list is what defines a good comment. **However**, we still have to remember that **every** comment **is our failure** to name our code better. If someone gives you a good hint how to remove a comment without sacrificing readability **we should go for it**.
+
+### How can we replace a comment?
+In case of a **what** comments usually it is very easy to replace a comment. Usually it's all about taking what comment says and create a variable or function with such a name.
+
+
+### How do we comment.
+Even with the approach explain above we will be forced to comment our code. I would like to propose a way of doing it. The biggest difficulty for me when I read a comment (especially a long one, explaining "why") is to understand to what scope the comment refers to. I think that we should always try to export commented code into a separate method and put the comment as a header to this method.
+
+The above solution have 2 benefits:
+
+1. It's visible to what part of a code comment refers.
+2. It improves readability for a developer who doesn't need to know why particular piece of code is written. Sometimes, during debugging for example, what you need to know is **what** happens, not **why**.
+
+To illustrate point `2.`. If there is an UIKit bug, with dismissing a modal screen which is ugly but works just fine, all we care about is the fact that the code has been dismissed. During a debuting we now we can go just further without a need to understand how `dissmissing` is handled.
+
+[This](https://github.com/Babylonpartners/babylon-ios/blob/2f815529362b03c316bf19bedc839a9028a6eab3/BabylonMapsUI/BabylonMapsUI/SearchResults/MapSearchResultsViewController.swift#L44) shows what is a good comment. Ideally, it could be exported to `self?.setDrawerState(drawerState)` to not disturb a reader when it's not necessary.
+ 
+
+
+## Impact on existing codebase
+It doesn't have any impact on existing codebase as this is about adding new rule to our StyleGuide. What will change is during code reviews we may have more comments how to replace a comment with a code.
+
+
+## Alternatives considered
+1. Leave the StyleGuide as it is, aka. reject this proposal.
+2. Modify the list of good comments.

--- a/Cookbook/Proposals/Comments.md
+++ b/Cookbook/Proposals/Comments.md
@@ -19,7 +19,7 @@ I'd like to extend what our style guide says on comments. Right now it says very
 
 ## Motivation
 
-I think we sometimes overuse comments. Because our StyleGuide doesn't say much on comments, we have different opinions whether a comment is worth to be added or not.
+I think we sometimes overuse comments. The reason for this our StyleGuide doesn't say much on comments and this leads us to having different opinions whether a comment is worth to be added or not in our Pull Requests.
 
 I think comments are rather bad than good because of 2 following reasons: 
 
@@ -42,7 +42,19 @@ public enum ConsultationMethod: String {
 ```
 At the beginning the `ConsultationMethod` had indeed 2 cases. This may be trivial here without big consequences however that not always a case and a lie may cost us many of hours.
 
-In our Pull Requests I've seen sometimes unnecessary
+"Cross-files" comments are even more dangerous to become a lie at some point. Consider the following comment:
+```
+/// Make the booking confirmation screen. The created screen would always refetch
+/// the appointment from the backend.
+public func makeBookingConfirmation(
+    with appointmentId: AppointmentDTO.ID,
+    presentingOn flow: Flow,
+    dismiss: @escaping () -> Void
+) -> UIViewController 
+```
+Such a comment is a leak of information from another file into Builder. Builder doesn't know how BusinessController works. A change in a BusinessController can change the behaviour of given  screen, while there won't be a need to even enter to the builder to find out there is a comment. At the end, comment stays there, unchanged.
+
+In our Pull Requests I've seen sometimes unnecessary comments
 ```swift
 extension AppointmentDTO {
     public enum State: String, Codable {
@@ -78,12 +90,10 @@ extension AppointmentDTO {
 }
 ```
 
-Moreover, commented code is not only longer but it is also fragile to become a lie at some point. When a comment contain an information from other scope (other file) in our codebase. When a developer changes something when particular action is used, he may even don't think he should change the comment as he won't see it until he enters the file. Will he enter the file? Sometimes there's no such a need.
-
 ## Proposed solution
 
 ### Our approach 
-The most important thing is to define our approach to comments as currently it isn't said clearly. Moreover, it would be nice to have a common way how we comment our code when we are forced to add them. 
+The most important thing is to improve definition of our approach to comments as currently it isn't said clearly. Moreover, it would be nice to have a common way how we comment our code when we are forced to add them. 
 
 In my opinion, our approach should insist on writing always a **self-documented code**. It should be our goal. However, writing self-documented code **doesn't** mean we shouldn't use comments. It means, that commenting our code is a **necessary evil**:
 
@@ -94,12 +104,18 @@ I think that adding the above section to our style guide would make it clear wha
 
 ### What is a good comment?
 
-To make our StyleGuide be more verbose we can also add a list of what kind of comments we think are "good".
+To make our StyleGuide more verbose we can also add a list of what kind of comments we think are "good".
 
 **Good comments**:
 
-- **Doc headers for public API**
 - **TODO comments**
+	This already have a good definition of our approach in the StyleGuide and I think we are fine with that approach.
+- **Doc headers for public API**
+	Good documentation helps consumers of the SDK to understand what the code does. However, I don't know if it's worth to add a comment to every public function/field, even if a comment is just a repetition. Following comment doesn't add any value (unless it's needed by a doc generation tool if we use any):
+	```swift
+	 /// Supported biometric types
+	 public var supportedBiometry: BiometryType
+	```
 - **Explanation of Intent/Clarification**
 	It's a kind of comment when a developer try to explain what he's trying to achieve when code is not verbose enough. Example: Math code, sometimes parsing.
 - **Warning of Consequences**
@@ -115,8 +131,8 @@ The above list is what defines a good comment. **However**, we still have to rem
 In case of a **what** comments usually it is very easy to replace a comment. Usually it's all about taking what comment says and create a variable or function with such a name.
 
 
-### How do we comment.
-Even with the approach explain above we will be forced to comment our code. I would like to propose a way of doing it. The biggest difficulty for me when I read a comment (especially a long one, explaining "why") is to understand to what scope the comment refers to. I think that we should always try to export commented code into a separate method and put the comment as a header to this method.
+### How do we comment?
+Even with the proposed approach we will be forced to comment our code at some point. I would like to propose a way of doing it. The biggest difficulty for me when I read a comment (especially a long one, explaining "why") is to understand to what scope the comment refers to. I think that we should always try to export commented code into a separate method/class and put the comment as a header to this method.
 
 The above solution have 2 benefits:
 
@@ -125,12 +141,81 @@ The above solution have 2 benefits:
 
 To illustrate point `2.`. If there is an UIKit bug, with dismissing a modal screen which is ugly but works just fine, all we care about is the fact that the code has been dismissed. During a debuting we now we can go just further without a need to understand how `dissmissing` is handled.
 
-[This](https://github.com/Babylonpartners/babylon-ios/blob/2f815529362b03c316bf19bedc839a9028a6eab3/BabylonMapsUI/BabylonMapsUI/SearchResults/MapSearchResultsViewController.swift#L44) shows what is a good comment. Ideally, it could be exported to `self?.setDrawerState(drawerState)` to not disturb a reader when it's not necessary.
+This shows what is a good comment:
+```swift
+		viewModel.state.signal
+			.observe(on: UIScheduler())
+			.observeValues { state in
+					let drawerState: DrawerState
+					switch state.status {
+							case .searching:
+		            drawerState = .fullyExpanded
+	            case .loading:
+                drawerState = .partiallyExpanded
+	            case let .loaded(places):
+                drawerState = places.isEmpty.isFalse
+                 ? .partiallyExpanded
+                 : .collapsed
+	            case .failed(.noPlaces):
+                 drawerState = .partiallyExpanded
+		          default:
+                 drawerState = (state.suggestions != nil)
+                 ? .partiallyExpanded
+                 : .collapsed
+        }
+        // Flow controls internal state of drawer presentation
+        // for example after it drawer is dismissed it shouldn't be possible
+        // to change its state without presenting it first.
+        // For that reason we change state through the flow
+        // and not through the self.drawerPresentationController.
+        // We can as well consider making this a default behaviour in DrawerKit
+        drawerFlow.setDrawerState(drawerState)
+}
+
+```
+
+
+ Ideally, it could be exported to `self?.setDrawerState(drawerState)` to not disturb a reader when it's not necessary:
+ 
+ ```swift
+    viewModel.state.signal
+      .observe(on: UIScheduler())
+      .observeValues { [weak self] state in
+        let drawerState: DrawerState
+        switch state.status {
+            case .searching:
+                drawerState = .fullyExpanded
+            case .loading:
+                drawerState = .partiallyExpanded
+            case let .loaded(places):
+                drawerState = places.isEmpty.isFalse
+                ? .partiallyExpanded
+                : .collapsed
+            case .failed(.noPlaces):
+                drawerState = .partiallyExpanded
+            default:
+                drawerState = (state.suggestions != nil)
+                ? .partiallyExpanded
+                : .collapsed
+        }
+        self?.setDrawerState(drawerState)
+    }
+
+// Flow controls internal state of drawer presentation
+// for example after it drawer is dismissed it shouldn't be possible
+// to change its state without presenting it first.        
+// For that reason we change state through the flow
+// and not through the self.drawerPresentationController.
+// We can as well consider making this a default behaviour in DrawerKit
+private func setDrawerState(_ drawerState: DrawerState) {
+	drawerFlow.setDrawerState(drawerState)
+}
+ ```
  
 
 
 ## Impact on existing codebase
-It doesn't have any impact on existing codebase as this is about adding new rule to our StyleGuide. What will change is during code reviews we may have more comments how to replace a comment with a code.
+It doesn't have any impact on existing codebase as this is about extending a rule in our StyleGuide. What will change is during code reviews we may have more suggestions how to replace a comment with a code.
 
 
 ## Alternatives considered

--- a/Cookbook/Proposals/Comments.md
+++ b/Cookbook/Proposals/Comments.md
@@ -221,3 +221,4 @@ It doesn't have any impact on existing codebase as this is about extending a rul
 ## Alternatives considered
 1. Leave the StyleGuide as it is, aka. reject this proposal.
 2. Modify the list of good comments. Maybe we don't agree on everything in this proposal but we like part of it.
+3. We can also extend this proposal to define our approach to `MARK`. Currentely, `MARK` is not covered in the Style Guide neither in this proposal.

--- a/Cookbook/Proposals/Comments.md
+++ b/Cookbook/Proposals/Comments.md
@@ -220,4 +220,4 @@ It doesn't have any impact on existing codebase as this is about extending a rul
 
 ## Alternatives considered
 1. Leave the StyleGuide as it is, aka. reject this proposal.
-2. Modify the list of good comments.
+2. Modify the list of good comments. Maybe we don't agree on everything in this proposal but we like part of it.


### PR DESCRIPTION
I'd like to suggest extending our point on comments in the StyleGuide. Sometimes in PRs I had a feeling we have a different approach to comments. Currently, the point on comments in the StyleGuide is not clear enough. 

Related PR: https://github.com/Babylonpartners/babylon-ios/pull/7606