### PR TITLE
Firebase info added to tools & services table

### DIFF
--- a/Cookbook/Technical-Documents/ToolsAndServices.md
+++ b/Cookbook/Technical-Documents/ToolsAndServices.md
@@ -16,6 +16,7 @@
 | VPN | Remote Access to our intranet and internal domains | [IT Support ticket](https://supportbybabylon.atlassian.net/servicedesk/customer/portal/5/group/12/create/43) |
 | [CircleCI](https://circleci.com/gh/Babylonpartners) | See CI jobs and logs | Use your GitHub login |
 | [HockeyApp](https://rink.hockeyapp.net/) | see OTA builds sent internally to QA | Ask support engineer in the iOS team channel on Slack to invite you to the org |
+| [Firebase](https://console.firebase.google.com/u/1/) | View crash reports, performance monitoring | Ask Rui for access |
 
 ## Internal tools
 

--- a/Cookbook/Technical-Documents/ToolsAndServices.md
+++ b/Cookbook/Technical-Documents/ToolsAndServices.md
@@ -16,7 +16,7 @@
 | VPN | Remote Access to our intranet and internal domains | [IT Support ticket](https://supportbybabylon.atlassian.net/servicedesk/customer/portal/5/group/12/create/43) |
 | [CircleCI](https://circleci.com/gh/Babylonpartners) | See CI jobs and logs | Use your GitHub login |
 | [HockeyApp](https://rink.hockeyapp.net/) | see OTA builds sent internally to QA | Ask support engineer in the iOS team channel on Slack to invite you to the org |
-| [Firebase](https://console.firebase.google.com/u/1/) | View crash reports, performance monitoring | Ask Rui for access |
+| [Firebase](https://console.firebase.google.com/u/1/) | View crash reports, performance monitoring | Ask Rui or David for access |
 
 ## Internal tools
 


### PR DESCRIPTION
Ticket: n/a
Zeplin: n/a

### Why?
Access to the IOS Team on firebase is needed to make use of the error messages posted in #ios-crash-reports, this fact is missing from the tools & services table within the cookbook

### How?
* Added a row to the table in the relevant .md file.

### PR checklist

* [x] I've assigned this PR to myself
* [x] I've set all the necessary PR's labels
* [] I've checked this PR's nature and I added, if needed, the title and ticket number to `CHANGELOG.md`. 

With :heart: