### PR TITLE
Document a naming convention for Step Definitions for UI Automation

### DIFF
--- a/Cookbook/README.md
+++ b/Cookbook/README.md
@@ -41,6 +41,7 @@ iOS Cookbook 👩‍🍳
     * [BBAddAdditionalPatientInformationViewControllerV2](./Technical-Documents/BBAddAdditionalPatientInformationViewControllerV2.md)
 
 * ✏️ What is Gherkin (the `Given` / `When` / `Then` / `And` formatting used by QA) and how can I determine its correctness in QA PRs
+* [UI Automation with Gherkin](./Technical-Documents/UIAutomation.md)
 * [Fastlane Match](./Technical-Documents/FastlaneMatch.md)
 * [How to invoke CI jobs from Slack](./Technical-Documents/SlackCIIntegration.md)
 * [Xcode Tips & Tricks](Technical-Documents/XcodeTips.md)

--- a/Cookbook/README.md
+++ b/Cookbook/README.md
@@ -40,7 +40,6 @@ iOS Cookbook 👩‍🍳
 * [Outstanding Technical Debt and Legacy Code](./Technical-Documents/TechnicalDebt.md)
     * [BBAddAdditionalPatientInformationViewControllerV2](./Technical-Documents/BBAddAdditionalPatientInformationViewControllerV2.md)
 
-* ✏️ What is Gherkin (the `Given` / `When` / `Then` / `And` formatting used by QA) and how can I determine its correctness in QA PRs
 * [UI Automation with Gherkin](./Technical-Documents/UIAutomation.md)
 * [Fastlane Match](./Technical-Documents/FastlaneMatch.md)
 * [How to invoke CI jobs from Slack](./Technical-Documents/SlackCIIntegration.md)

--- a/Cookbook/Technical-Documents/UIAutomation.md
+++ b/Cookbook/Technical-Documents/UIAutomation.md
@@ -4,7 +4,7 @@ As part of our UI automation we utilize the open source Gherkin framework [Links
 ##Step Definitions
 In order to support the Gherkin syntax, communally referred to as cucumber, we use XCTest-Gherkin. This allows test scenarios to be written in a human readable language which can match the description in TestRail. Gherkin uses a set of keywords to give structure and meaning to executable step definitions. When defining these step definition we use a naming convention.
 
-##Naming Convention
+## Naming Convention
 Step definitions are broken down into a number of key actions, each with their own naming convention.Though not all our steps have been updated to this convention.
 
 ### User Actions

--- a/Cookbook/Technical-Documents/UIAutomation.md
+++ b/Cookbook/Technical-Documents/UIAutomation.md
@@ -23,7 +23,7 @@ step("the Settings screen is displayed")
 step("the user is returned to the home screen")
 ```
 
-###Non User Actions
+### Non User Actions
 This is intended as a catch all for "mocked" or "simulated" or "API" call, these normally begin with "a" but not always. These are normally part of the Given component of the test scenarios in order to speed up tests.
 ```javascript
 step("a registered verified user logs in with \"(.*?)\" credentials")

--- a/Cookbook/Technical-Documents/UIAutomation.md
+++ b/Cookbook/Technical-Documents/UIAutomation.md
@@ -15,7 +15,7 @@ step("I click done on appointment confirmation screen")
 step("I tap on the child account holder")
 ```
 
-###System State or Responses
+### System State or Responses
 In order to check a state in the application or if the application has completed a action we use "the"
 ```javascript
 step("the Prescription screen with delivery address is displayed")

--- a/Cookbook/Technical-Documents/UIAutomation.md
+++ b/Cookbook/Technical-Documents/UIAutomation.md
@@ -1,4 +1,4 @@
-# UI Automation with XCTest
+# UI Automation with XCTest & Gherkin
 As part of our UI automation we utilize the open source Gherkin framework [Links with title](https://github.com/net-a-porter-mobile/XCTest-Gherkin "XCTest-Gherkin") to make the test cases more readable and use the screen object model to improve maintainability of the test code.
 
 ## Step Definitions

--- a/Cookbook/Technical-Documents/UIAutomation.md
+++ b/Cookbook/Technical-Documents/UIAutomation.md
@@ -1,4 +1,4 @@
-#UI Automation with XCTest
+# UI Automation with XCTest
 As part of our UI automation we utilize the open source Gherkin framework [Links with title](https://github.com/net-a-porter-mobile/XCTest-Gherkin "XCTest-Gherkin") to make the test cases more readable and use the screen object model to improve maintainability of the test code.
 
 ##Step Definitions

--- a/Cookbook/Technical-Documents/UIAutomation.md
+++ b/Cookbook/Technical-Documents/UIAutomation.md
@@ -7,7 +7,7 @@ In order to support the Gherkin syntax, communally referred to as cucumber, we u
 ##Naming Convention
 Step definitions are broken down into a number of key actions, each with their own naming convention.Though not all our steps have been updated to this convention.
 
-###User Actions
+### User Actions
 For user actions we use the prefix "I" do something, for example
 ```javascript
 step("I consent to switching NHS GP")

--- a/Cookbook/Technical-Documents/UIAutomation.md
+++ b/Cookbook/Technical-Documents/UIAutomation.md
@@ -1,7 +1,7 @@
 # UI Automation with XCTest
 As part of our UI automation we utilize the open source Gherkin framework [Links with title](https://github.com/net-a-porter-mobile/XCTest-Gherkin "XCTest-Gherkin") to make the test cases more readable and use the screen object model to improve maintainability of the test code.
 
-##Step Definitions
+## Step Definitions
 In order to support the Gherkin syntax, communally referred to as cucumber, we use XCTest-Gherkin. This allows test scenarios to be written in a human readable language which can match the description in TestRail. Gherkin uses a set of keywords to give structure and meaning to executable step definitions. When defining these step definition we use a naming convention.
 
 ## Naming Convention

--- a/Cookbook/Technical-Documents/UIAutomation.md
+++ b/Cookbook/Technical-Documents/UIAutomation.md
@@ -1,0 +1,32 @@
+#UI Automation with XCTest
+As part of our UI automation we utilize the open source Gherkin framework [Links with title](https://github.com/net-a-porter-mobile/XCTest-Gherkin "XCTest-Gherkin") to make the test cases more readable and use the screen object model to improve maintainability of the test code.
+
+##Step Definitions
+In order to support the Gherkin syntax, communally referred to as cucumber, we use XCTest-Gherkin. This allows test scenarios to be written in a human readable language which can match the description in TestRail. Gherkin uses a set of keywords to give structure and meaning to executable step definitions. When defining these step definition we use a naming convention.
+
+##Naming Convention
+Step definitions are broken down into a number of key actions, each with their own naming convention.Though not all our steps have been updated to this convention.
+
+###User Actions
+For user actions we use the prefix "I" do something, for example
+```javascript
+step("I consent to switching NHS GP")
+step("I click done on appointment confirmation screen")
+step("I tap on the child account holder")
+```
+
+###System State or Responses
+In order to check a state in the application or if the application has completed a action we use "the"
+```javascript
+step("the Prescription screen with delivery address is displayed")
+step("the Settings screen is displayed")
+step("the user is returned to the home screen")
+```
+
+###Non User Actions
+This is intended as a catch all for "mocked" or "simulated" or "API" call, these normally begin with "a" but not always. These are normally part of the Given component of the test scenarios in order to speed up tests.
+```javascript
+step("a registered verified user logs in with \"(.*?)\" credentials")
+step("a GP is added to the child family member")
+step("verify user in the background")
+```


### PR DESCRIPTION
Recently I have received a number of questions about defining new step definitions. Which is currently documented on confluence, so I decide to propose moving the naming convention to the ios-playbook, with the aim to expand the document as I receive more questions from the developer.