### PR TITLE
Add DebugBuilder.md

### DIFF
--- a/Cookbook/Technical-Documents/DebugBuilder.md
+++ b/Cookbook/Technical-Documents/DebugBuilder.md
@@ -12,9 +12,10 @@ This feature improves overall UI debugging iteration speed.
 1. Add a new case in `enum DebugBuilderPattern`
 2. Create a (mock) builder in `DebugAuthenticatedRootBuilder`
 3. Update `Settings.bundle/Root.plist` by adding a new case key
+    - NOTE: There exists multiple `Settings.bundle`s due to multiple app targets
 4. Build and launch your app at least once after those changes, so that the Settings app can now discover the new values in the `Root.plist`
-4. Set `Settings.bundle`'s userDefaults flag via `Settings.app`
-5. Launch the app
+5. Set `Settings.bundle`'s userDefaults flag via `Settings.app`
+6. Launch the app
 
 ## Example
 

--- a/Cookbook/Technical-Documents/DebugBuilder.md
+++ b/Cookbook/Technical-Documents/DebugBuilder.md
@@ -12,6 +12,7 @@ This feature improves overall UI debugging iteration speed.
 1. Add a new case in `enum DebugBuilderPattern`
 2. Create a (mock) builder in `DebugAuthenticatedRootBuilder`
 3. Update `Settings.bundle/Root.plist` by adding a new case key
+4. Build and launch your app at least once after those changes, so that the Settings app can now discover the new values in the `Root.plist`
 4. Set `Settings.bundle`'s userDefaults flag via `Settings.app`
 5. Launch the app
 

--- a/Cookbook/Technical-Documents/DebugBuilder.md
+++ b/Cookbook/Technical-Documents/DebugBuilder.md
@@ -21,7 +21,7 @@ This feature improves overall UI debugging iteration speed.
 
 ```diff
  public enum DebugBuilderPattern: String {
-     case none
+     case disabled
      ...
 
 +    // NOTE: Add a new debug builder case here.

--- a/Cookbook/Technical-Documents/DebugBuilder.md
+++ b/Cookbook/Technical-Documents/DebugBuilder.md
@@ -3,7 +3,7 @@ Debug Builder
 
 [\[CNSMR\-1602\] Add \`DebugAuthenticatedRootBuilder\` for faster UI debugging iteration by inamiy · Pull Request \#7645 · Babylonpartners/babylon\-ios](https://github.com/Babylonpartners/babylon-ios/pull/7645)
 
-Above PR introduces `DebugAuthenticatedRootBuilder` that allows to directly show a target view builder after authentication.
+The above PR introduces `DebugAuthenticatedRootBuilder` which allows to directly show a target view builder after authentication.
 
 This feature improves overall UI debugging iteration speed.
 

--- a/Cookbook/Technical-Documents/DebugBuilder.md
+++ b/Cookbook/Technical-Documents/DebugBuilder.md
@@ -5,7 +5,7 @@ Debug Builder
 
 The above PR introduces `DebugAuthenticatedRootBuilder` which allows to directly show a target view builder after authentication.
 
-This feature improves overall UI debugging iteration speed.
+This feature improves the overall iteration speed for UI debugging.
 
 ## How to make a debug-builder
 

--- a/Cookbook/Technical-Documents/DebugBuilder.md
+++ b/Cookbook/Technical-Documents/DebugBuilder.md
@@ -1,0 +1,96 @@
+Debug Builder
+======================
+
+[\[CNSMR\-1602\] Add \`DebugAuthenticatedRootBuilder\` for faster UI debugging iteration by inamiy · Pull Request \#7645 · Babylonpartners/babylon\-ios](https://github.com/Babylonpartners/babylon-ios/pull/7645)
+
+Above PR introduces `DebugAuthenticatedRootBuilder` that allows to directly show a target view builder after authentication.
+
+This feature improves overall UI debugging iteration speed.
+
+## How to make a debug-builder
+
+1. Add a new case in `enum DebugBuilderPattern`
+2. Create a (mock) builder in `DebugAuthenticatedRootBuilder`
+3. Update `Settings.bundle/Root.plist` by adding a new case key
+4. Set `Settings.bundle`'s userDefaults flag via `Settings.app`
+5. Launch the app
+
+## Example
+
+`LocalFeatureSwitches.swift`
+
+```diff
+ public enum DebugBuilderPattern: String {
+     case none
+     ...
+
++    // NOTE: Add a new debug builder case here.
++    case eligibilityCheckBuilder
+ }
+```
+
+`DebugAuthenticatedRootBuilder.swift`
+
+```diff
+ final class DebugAuthenticatedRootBuilder {
+     private let dependencies: AppDependencies
+     private let syncOrchestrator: SyncOrchestrator
+
+     ...
+
+     func make(
+         session: MainUserSession,
+         authenticatedPushEvents: Signal<PushEvent, NoError>,
+         authenticatedApplicationInvocationEvents: Signal<ApplicationInvocation, NoError>,
+         lifecycleEvents: Signal<LifecycleEvent, NoError>
+     ) -> UIViewController? {
+
+         switch LocalFeatureSwitches.debugBuilder {
+         ...
+
++        // NOTE: Implement a new mock builder here.
++        case .eligibilityCheckBuilder:
++            let builder = EligibilityCheckBuilder(dependencies: dependencies, session: session)
++            return DesignLibrary.viewControllersBuilder().navigationController(dismissalStyle: .pop) { (navigation, modal) -> UIViewController in
++                return builder.make(
++                    navigation: navigation,
++                    modal: modal,
++                    presenting: modal,
++                    root: modal,
++                    switchFlow: NHSSwitchFlow(
++                        flow: modal,
++                        rootViewController: UIApplication.shared.delegate?.window??.rootViewController!
++                    )
++                )
++            }
++    }
+ }
+```
+
+`Settings.bundle/Root.plist`
+
+```diff
+         <dict>
+             <key>Type</key>
+             <string>PSMultiValueSpecifier</string>
+             <key>Title</key>
+             <string>Debug Builder</string>
+             <key>Key</key>
+             <string>debugBuilder</string>
+             <key>DefaultValue</key>
+             <string>none</string>
+             <key>Values</key>
+             <array>
+                 <string>none</string>
+                 <string>forgotPasswordBuilder</string>
+                 ...
++                <string>eligibilityCheckBuilder</string>
+             </array>
+             <key>Titles</key>
+             <array>
+                 <string>none</string>
+                 ...
++                <string>eligibilityCheckBuilder</string>
+             </array>
+         </dict>
+```


### PR DESCRIPTION
This PR is a documentation for Debug Builder https://github.com/Babylonpartners/babylon-ios/pull/7645 .
(Confirmed that this doesn't need a proposal)

The main purpose of this feature is to quickly open the deeply-nested screen for faster UI debugging iteration.

#### How to make a debug-builder

1. Add a new case in `enum DebugBuilderPattern`
2. Create a (mock) builder in `DebugAuthenticatedRootBuilder`
3. Update `Settings.bundle/Root.plist` by adding a new case key
4. Set `Settings.bundle`'s userDefaults flag via `Settings.app`
5. Launch the app