### PR TITLE
Describe using `AccessibilityContent` for elements and screens

### DIFF
--- a/Cookbook/Technical-Documents/AutomationIdentifiers.md
+++ b/Cookbook/Technical-Documents/AutomationIdentifiers.md
@@ -85,12 +85,14 @@ After this identifier has been set on a control, we can `import BabylonDependenc
 
 ``` swift
 let promofield = app.tables
-    .cells[AccessibilityContent.PromoCode.codeCell]
+    .matching(.cell, identifier: AccessibilityContent.PromoCode.codeCell)
     .textFields
     .firstMatch
 ```
 
-Note that the identifier is usually set on the cell itself rather than its internal components, as automation has problems finding elements otherwise.
+Note that you may need to set the identifier on the cell itself rather than its internal components, as automation may have problems finding elements otherwise.
+
+It is also preferable to always use `.matching(.cell, identifier: …).firstMatch` rathen than a subscript (`[…]`) as the subscript variant only expects a single match. If, for some reason, there are several, it will throw an error.
 
 ### Taking advantage of ScreenNaming for screen identifiers
 

--- a/Cookbook/Technical-Documents/AutomationIdentifiers.md
+++ b/Cookbook/Technical-Documents/AutomationIdentifiers.md
@@ -2,21 +2,21 @@
 
 ## Updating how Screen Elements are located
 
-One of the challenges/maintenance activities we face with our UI tests is that the majority of elements do not have an `accessibilityIdentifier` defined and the value of the element was used instead. This made the tests more fragile to changes in copy and require a corresponding update to the automation. Normally we need to update how elements are located because the text has changed either in lokalise or a backend response.
+One of the challenges/maintenance activities we face with our UI tests is that the majority of elements do not have an `accessibilityIdentifier` defined and the value of the element is used instead. This makes the tests more fragile to changes in copy and requires a corresponding update to the automation. Normally we need to update how elements are located because the text has changed either in lokalise or a backend response.
 
 This page covers why this happens and how we can improve the testing moving forward.
 
 ## How to Find Elements
 
-The most efficient way to locate a *XCUIElement* on screen is to use accessibility combined with a query. The framework supports among other methods accessibility labels and accessibility identifiers. We should avoid using accessibility labels because these are used by VoiceOver, can be localized and can be accessed by external tools. Accessibility identifier's are developer-facing, not localized and is the method recommended by Apple.
+The most efficient way to locate an `XCUIElement` on screen is to use accessibility combined with a query. The framework supports among other methods accessibility labels and accessibility identifiers. We should avoid using accessibility labels because these are used by VoiceOver, can be localized and can be accessed by external tools. Accessibility identifiers are developer-facing, not localized and is the method recommended by Apple.
 
 ### Locating Elements
 
-Identification of `XCUIElements` in automation code should be done in the screen objects and screen objects should not reference each other. If interacting with an element is handled elsewhere this is probably a bug. Though in some cases the identifiers are injected at run time, this has been used in content driven screens i.e. promo code details.
+Identification of `XCUIElement`s in automation code should be done in the screen objects and screen objects should not reference each other. If interacting with an element is handled elsewhere this is probably a bug. Though in some cases the identifiers are injected at run time, this has been used in content driven screens i.e. promo code details.
 
 #### Identifiers
 
-The identifiers are strings defined in a Screen Object namespace using a private enum or injected into the constructor of Screen Object. As you can see from the example below, we have used both accessibility identifiers and the text within the element to locate XCUIElement's.
+The identifiers are strings defined in a Screen Object namespace using a private enum or injected into the constructor of Screen Object. As you can see from the example below, we have used both accessibility identifiers and the text within the element to locate `XCUIElement`s.
 
 ##### Chatbot Bento Screen
 
@@ -44,7 +44,7 @@ fileprivate enum StaticTexts {
 
 #### Queries
 
-The other way to find an element is using a `XCUIElementQuery` which can either make use of an identifier or not. The key difference is that a query requires detailed knowledge of the screen layout and is more commonly used when several `XCUIElement` with the same identifier are displayed on the screens i.e. the address list.
+The other way to find an element is using an `XCUIElementQuery` which can either make use of an identifier or not. The key difference is that a query requires detailed knowledge of the screen layout and is more commonly used when several `XCUIElement`s with the same identifier are displayed on the screens i.e. the address list.
 
 ##### Examples
 
@@ -55,7 +55,7 @@ The other way to find an element is using a `XCUIElementQuery` which can either 
 
 ## Updating Locators
 
-The quick solution is to simply update the enum. When an identifier's text has changed, this is very straight forward and simple. Update the text defined in the enum to the correct value and automation should start working. Resulting in Pull Requests like this https://github.com/Babylonpartners/babylon-ios/pull/6475
+The quick solution is to simply update the enum. When an identifier's text has changed, this is very straightforward and simple. Update the text defined in the enum to the correct value and automation should start working. Resulting in Pull Requests like this https://github.com/Babylonpartners/babylon-ios/pull/6475
 
 ```swift
 fileprivate enum NavigationBar {
@@ -67,7 +67,7 @@ fileprivate enum NavigationBar {
 
 While this will fix the test, it is susceptible to future changes. In this case time permitting, we should attempt to define an `accessibilityIdentifier` for the element and then update the enum to use this identifier. This is not always possible as in the case with chat responses, but it is something we should strive for in order to make our tests more stable and maintainable, reducing the amount of updates needed in the future.
 
-#### Updating Queries
+### Updating Queries
 
 The most common root cause is that the `XCUIElementQuery` requires an update. The thing we need to consider is that the performance of the XCTest framework is affected by how much of the view hierarchy is searched when looking for an element. This is because the framework will by default search the entire view hierarchy. This is time consuming, the recommended solution is to give the query as much information as possible. For example, below, we are telling the framework that the button is within an alert, this improves the performance of the test.
 
@@ -75,7 +75,7 @@ The most common root cause is that the `XCUIElementQuery` requires an update. Th
 let okButton = app.alerts.buttons[Buttons.okButton]
 ```
 
-But comes at the cost, that if the layout changes, the query itself, not the identifier can be broken. In this case the query will need to be updated, to reflect the change, i.e. if the buttons moves from the alert to table. Then the query should be updated to:
+But comes at the cost, that if the layout changes, the query itself, not the identifier can be broken. In this case the query will need to be updated to reflect the change, i.e. if the button moves from the alert to table. Then the query should be updated to:
 
 ```swift
 let okButton = app.tables.buttons[Buttons.okButton]
@@ -83,7 +83,7 @@ let okButton = app.tables.buttons[Buttons.okButton]
 
 This will fix the issue, while not changing the identifier itself.
 
-#### Accessibility Identifier Naming
+### Accessibility Identifier Naming
 
 This is something that tends to be subjective. But in general I would recommend using the naming convention used in ChatBot Bento, which has worked well. The key requirement is that identifier should be unique to each screen, except when used in a dynamic list i.e an address list. Also if the element itself can be present on multiple screens we should also include a reference to the screen in the name.
 

--- a/Cookbook/Technical-Documents/AutomationIdentifiers.md
+++ b/Cookbook/Technical-Documents/AutomationIdentifiers.md
@@ -170,4 +170,4 @@ For example in the registration screen I would recommend the following for the "
 - **"letsGo"**
 
 However for the first name field as this is present in multiple screens I would use:
-    - **"registerFirstName"**
+- **"registerFirstName"**


### PR DESCRIPTION
As we can now use `AccessibilityContent` in automation, we should try and do that more, and rely less on copy, same for locating if a screen is displayed.

Also fixes some typos and header levels.

---

I'm interested in feedback re: `ScreenNaming`, as it's now used in home screen and notifications.