### PR TITLE
Update CODE_REVIEW.md

### DIFF
--- a/Etiquette/CODE_REVIEW.md
+++ b/Etiquette/CODE_REVIEW.md
@@ -59,7 +59,7 @@ Reviewing a Pull Request
 * Do not try to make everything perfect (it never will be and otherwise we'll never deliver anything), but do not compromise on quality
 * Do not comment if you don't have any suggestions to address your comment
 * Use GitHub suggestions as much as possible
-* If you feel strong against the change - please use `Request changes` and explain why you are doing that. **Any comment left in the PR is taken as a suggestion, and it's up to the author's discretion to accept them or not, except if you use `Request changes`.**
+* If you feel strongly against the change - please use `Request changes` and explain why you are doing that. **Any comment left in the PR is taken as a suggestion, and it's up to the author's discretion to accept them or not, except if you use `Request changes`.**
 * Approve changes if you are confident about them. 
 * If you are the first reviewer to approve the changes add the label "Needs one reviewer" so that others can see which PRs already have a feedback and which don't have any yet.
 * Comment on the changes if something is not clear to you and needs further clarification or actions

--- a/Etiquette/CODE_REVIEW.md
+++ b/Etiquette/CODE_REVIEW.md
@@ -59,7 +59,7 @@ Reviewing a Pull Request
 * Do not try to make everything perfect (it never will be and otherwise we'll never deliver anything), but do not compromise on quality
 * Do not comment if you don't have any suggestions to address your comment
 * Use GitHub suggestions as much as possible
-* If you feel strong against the change - request changes and explain why you are doing that. Do not request changes for typos, missing documentation comments or code style violations, trust your colleagues to address them.
+* If you feel strong against the change - please use `Request changes` and explain why you are doing that. **Any comment left in the PR is taken as a suggestion, and it's up to the author's discretion to accept them or not, except if you use `Request changes`.**
 * Approve changes if you are confident about them. 
 * If you are the first reviewer to approve the changes add the label "Needs one reviewer" so that others can see which PRs already have a feedback and which don't have any yet.
 * Comment on the changes if something is not clear to you and needs further clarification or actions

--- a/Etiquette/CODE_REVIEW.md
+++ b/Etiquette/CODE_REVIEW.md
@@ -59,7 +59,7 @@ Reviewing a Pull Request
 * Do not try to make everything perfect (it never will be and otherwise we'll never deliver anything), but do not compromise on quality
 * Do not comment if you don't have any suggestions to address your comment
 * Use GitHub suggestions as much as possible
-* If you feel strongly against the change - please use `Request changes` and explain why you are doing that. **Any comment left in the PR is taken as a suggestion, and it's up to the author's discretion to accept them or not, except if you use `Request changes`.**
+* If you feel strongly against the change - please use `Request changes` and explain why you are doing that. **Any comment left in the PR is taken as a suggestion, and it's up to the author's discretion to accept them or not, except if you use `Request changes`.** Not every comment has to be addressed, but every comment has to be acknowledged.
 * Approve changes if you are confident about them. 
 * If you are the first reviewer to approve the changes add the label "Needs one reviewer" so that others can see which PRs already have a feedback and which don't have any yet.
 * Comment on the changes if something is not clear to you and needs further clarification or actions


### PR DESCRIPTION
Added change based on the following:


> Given recent events, I think it would be good for us to agree on the following when it comes to PR etiquette. Because we are a remote team, with different background and cultures, sometimes our intentions and words are not clear to each other and, as such, we remain in this grey area where we don’t know what the other person means. I want to suggest the following:
>
> -> Any comment left in a PR is “just” a suggestion, except if the Author of said comment blocks the PR.
>
> The goal here is to differentiate between “This is wrong because `X` and I would advise doing `Y`” *versus* “Maybe you should do `Y` instead”. The former brings objective feedback, that can be actionable by the PR author, while the latter is an opinion. Said opinion, can be considered by the Author, but nothing is forcing him/her to follow it.
```