### PR TITLE
Add PullAssigner doc in README + mention limitation about team auto-removal

### DIFF
--- a/Cookbook/README.md
+++ b/Cookbook/README.md
@@ -47,3 +47,4 @@ iOS Cookbook 👩‍🍳
 * [Code Signing with Fastlane Match](./Technical-Documents/FastlaneMatch.md)
 * [How to invoke CI jobs from Slack](./Technical-Documents/SlackCIIntegration.md)
 * [Xcode Tips & Tricks](Technical-Documents/XcodeTips.md)
+* [Configure PullAssigner on our repos](Technical-Documents/PullAssigners.md)

--- a/Cookbook/Technical-Documents/PullAssigners.md
+++ b/Cookbook/Technical-Documents/PullAssigners.md
@@ -41,7 +41,9 @@ But if you have created new teams (team listing reviewers + proxy team) you'll n
 
  - Click "Add Team"
  - Select the real (not proxy) team you've created before in the dropdown menu
- - Configure the team in the next screen, especially the number of reviewers to assign, the algorithm, but also the proxy team you previously created, and select to delete that (proxy) team review request after assigning reviewers.
+ - Configure the team in the next screen, especially the number of reviewers to assign, the algorithm, but also the proxy team you previously created, and select to delete that (proxy) team review request after assigning reviewers (†).
+
+ (†) Note that if your repository's protected branch is configured with "Require review from Code Owners" checked, then any team in your `CODEOWNERS` will stay assigned as reviewer – which means that your proxy team, being typically part of your `CODEOWNERS` itself, won't be removed from your PR even if you chose "Delete after assigning reviewer(s)" for the "Team review request" setting in your https://pullreminders.com setup. It will only be able to be deleted if the "Require review from Code Owners" setting is unchecked in your repo.
 
 ## Update GitHub's PullAssigner app settings
 

--- a/Cookbook/Technical-Documents/PullAssigners.md
+++ b/Cookbook/Technical-Documents/PullAssigners.md
@@ -43,7 +43,7 @@ But if you have created new teams (team listing reviewers + proxy team) you'll n
  - Select the real (not proxy) team you've created before in the dropdown menu
  - Configure the team in the next screen, especially the number of reviewers to assign, the algorithm, but also the proxy team you previously created, and select to delete that (proxy) team review request after assigning reviewers (†).
 
- (†) Note that if your repository's protected branch is configured with "Require review from Code Owners" checked, then any team in your `CODEOWNERS` will stay assigned as reviewer – which means that your proxy team, being typically part of your `CODEOWNERS` itself, won't be removed from your PR even if you chose "Delete after assigning reviewer(s)" for the "Team review request" setting in your https://pullreminders.com setup. It will only be able to be deleted if the "Require review from Code Owners" setting is unchecked in your repo.
+ (†) Note that if your repository's protected branch is configured with "Require review from Code Owners" checked, then any member or team mentioned in your `CODEOWNERS` file will stay assigned as reviewer. Which means that in that case, your proxy team, being typically mentioned in your `CODEOWNERS` to always be auto-assigned, won't be removed from your PR even if you chose "Delete after assigning reviewer(s)" for the "Team review request" setting in your https://pullreminders.com setup. It will only be able to be deleted if the "Require review from Code Owners" setting is unchecked in your repo.
 
 ## Update GitHub's PullAssigner app settings
 


### PR DESCRIPTION
Currently on our bot repos, we have "Require approval from code owners" so the PA team isn't removed from reviewers (while it is in playbook and in main repo)