### PR TITLE
Suggested updates for on boarding

### DIFF
--- a/Cookbook/Technical-Documents/NewHiresCheckList.md
+++ b/Cookbook/Technical-Documents/NewHiresCheckList.md
@@ -66,7 +66,7 @@ Make sure you also join your Tribe/Squad's Slack channels.
 Most of the work to get the iOS project up and running is automated inside a
 shell script. Here's how to get the iOS project up and running:
 
-1. [Generate](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) & add the SSH key to your [GitHub account](https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account)
+1. [Generate](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key), add the SSH key to your [GitHub account](https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account) and [authorise](https://help.github.com/en/articles/authorizing-an-ssh-key-for-use-with-a-saml-single-sign-on-organization) it for use with single sign on.
 
 1. Run the `ios-onboarding` Bash script inside the `scripts` directory of this
    repo. It requires a `CODE_DIRECTORY` argument which is the parent directory

--- a/Cookbook/Technical-Documents/NewHiresCheckList.md
+++ b/Cookbook/Technical-Documents/NewHiresCheckList.md
@@ -35,11 +35,6 @@ As an iOS Engineer, you should be in the following Slack channels:
 	- `#demo_frontend`
 	- `#developers`
 
-* Slack Apps
-	- pull-reminders
-	- peakon
-	- betterworks
-
 Make sure you also join your Tribe/Squad's Slack channels.
 
 ## Install prerequisites

--- a/Cookbook/Technical-Documents/ToolsAndServices.md
+++ b/Cookbook/Technical-Documents/ToolsAndServices.md
@@ -15,6 +15,7 @@
 | [zoom.us](https://zoom.us/) | Video Conferences | Create account with BabylonHealth email-Id. You will have access to basic plan (you can join invites without an account but will need one to create conferences)|
 | VPN | Remote Access to our intranet and internal domains | [IT Support ticket](https://supportbybabylon.atlassian.net/servicedesk/customer/portal/5/group/12/create/43) |
 | [CircleCI](https://circleci.com/gh/Babylonpartners) | See CI jobs and logs | Use your GitHub login |
+| [Pull Panda](https://pullreminders.com) | Stats on PRs and reminders for when you've been asked for a review | Use your GitHub login |
 | [HockeyApp](https://rink.hockeyapp.net/) | see OTA builds sent internally to QA | Ask support engineer in the iOS team channel on Slack to invite you to the org |
 | [Firebase](https://console.firebase.google.com/u/1/) | View crash reports, performance monitoring | Ask Rui or David for access |
 

--- a/scripts/ios-onboarding
+++ b/scripts/ios-onboarding
@@ -41,7 +41,7 @@ cd "${target_directory}"
 ./Templates/install_xcode_templates.sh
 
 # Install project dependencies (Ruby gems and Cocoapods pods).
-gem install bundler -v '~> 1.0'
+gem install bundler -v '~> 2.0'
 bundle install
 bundle exec pod install
 


### PR DESCRIPTION
- Add SSO link to github ssh generation instructions.
- Install bundler 2.0.x. babylon-ios gemfile.lock in project has been bundled with 2.0.x for a while now
- remove redundant slack apps as far as I can see these are either deprecated or require no set up (in slack), but I moved pull panda into "services"