### PR TITLE
Update monitor squads

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ By definition, members work on their respective squad, although they are free to
 | Enrolment and Integrity       | James                                |    1/1       | [#ei-squad](https://babylonhealth.slack.com/archives/CGR4D5NKX) |
 | Healthcheck                   | Ben, Julien                                 |    2/3       | [#healthcheck_tribe](https://babylonhealth.slack.com/archives/C7995CX3R) |
 | Monitor (Bulbasaur)           | Joshua, Dan                                 |    2/2       | |
-| Monitor (Charmander)          | Anders                                      |    1/1       |  |
+| Monitor (Charmander)          | Anders                                      |    1/2       |  |
 | Monitor (Squirtle)            | Daniel H., Diego                            |    2/2       |  |
 | Native Apps                   | Giorgos, Jason, Martin, Inami, Emese        |    5/5       | [#nativeapps_public](https://babylonhealth.slack.com/archives/CE5P8LRNH) |
 | Prescriptions                 | Adam, Konrad                                |    2/2       | [#prescription-squad](https://babylonhealth.slack.com/archives/C88TCM9JB) |

--- a/README.md
+++ b/README.md
@@ -66,14 +66,15 @@ By definition, members work on their respective squad, although they are free to
 | Squad Name                    | Members                                     | Availability | Public slack channel |
 |-------------------------------|---------------------------------------------| ------------ | -------------------- |
 | Booking                       | Witold                                      |    1/1       | |
-| Condition Management          | Catarina, João, Dan S., Diego                      |    4/4       | [#health-mgmt-public](https://babylonhealth.slack.com/archives/CCNHJUXLH) | 
 | Consultation                  | Adrian, Chitra                              |    2/2       | |
 | Core Experience               | Sergey, Yuri                                |    2/2       | [#core-exp-squad](https://babylonhealth.slack.com/archives/CCSE8JLK0) |
 | Dev Experience                | Ilya, Olivier, David                        |    3/3       | [#mobile-tooling](https://babylonhealth.slack.com/messages/CL3QSC2NM) |
 | Early Feedback                | Danilo                                      |    1/1       | [#early_feedback](https://babylonhealth.slack.com/archives/CLGA76GG7) |
 | Enrolment and Integrity       | James                                |    1/1       | [#ei-squad](https://babylonhealth.slack.com/archives/CGR4D5NKX) |
 | Healthcheck                   | Ben, Julien                                 |    2/3       | [#healthcheck_tribe](https://babylonhealth.slack.com/archives/C7995CX3R) |
-| Monitor                       | Anders, Joshua, Daniel H.                      |    3/3       | [#patient-metrics-team](https://babylonhealth.slack.com/archives/CE37S5W9Z) |
+| Monitor (Bulbasaur)           | Joshua, Dan                                 |    2/2       | |
+| Monitor (Charmander)          | Anders                                      |    1/1       |  |
+| Monitor (Squirtle)            | Daniel H., Diego                            |    2/2       |  |
 | Native Apps                   | Giorgos, Jason, Martin, Inami, Emese        |    5/5       | [#nativeapps_public](https://babylonhealth.slack.com/archives/CE5P8LRNH) |
 | Prescriptions                 | Adam, Konrad                                |    2/2       | [#prescription-squad](https://babylonhealth.slack.com/archives/C88TCM9JB) |
 | Professional Services         | Simon                                       |    1/3       | [#telus](https://babylonhealth.slack.com/archives/CAJ7YQZ5Z) |


### PR DESCRIPTION
The monitor squad has recently been split into three squadlets, so the playbook should reflect that.