### PR TITLE
Clarify that ScreenNaming protocol unit tests

### DIFF
--- a/Cookbook/Technical-Documents/SnowplowHowTo.md
+++ b/Cookbook/Technical-Documents/SnowplowHowTo.md
@@ -128,6 +128,7 @@ class AchievementUnlockedEventTests: XCTestCase {
     }
 }
 ```
+Note: ViewModels conforming to the ScreenNaming protocol will not fire screen events as stand alone view models. 
 
 ## UI Tests for Snowplow Events
 


### PR DESCRIPTION
Clarify that the ScreenNaming protocol on the view model won't trigger any events without a view controller