### PR TITLE
Update team members and squad allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,8 @@ The rest of the iOS Engineers work in the following squads:
     <tr><td rowspan='2' valign='top'><strong>Consultation</strong><br/>Consultation experience related features including, but not limited to - audio/video call and replay quality, consultation feedback, pre-consultation preparation and reminders for consultation</td>
       <td>Adrian Śliwa</td><td><a href='https://github.com/adiki'>@adiki</a></td><td><a href='https://twitter.com/adiki91'>@adiki91</a></td></tr>
       <tr><td>Chitra Kotwani</td><td><a href='https://github.com/chitrakotwani'>@chitrakotwani</a></td><td><a href='https://twitter.com/chitrakotwani'>@chitrakotwani</a></td></tr>
-    <tr><td rowspan='4' valign='top'><strong>Onboarding and Navigation</strong><br/>General user experience in the app.</td>
+    <tr><td rowspan='3' valign='top'><strong>Onboarding and Navigation</strong><br/>General user experience in the app.</td>
       <td>Emese Toth</td><td><a href='https://github.com/emeseuk'>@emeseuk</a></td><td></td></tr>
-      <tr><td>Giorgos Tsiapaliokas</td><td><a href='https://github.com/gtsiap'>@gtsiap</a></td><td></td></tr>
       <tr><td>Sergey Shulga</td><td><a href='https://github.com/sergdort'>@sergdort</a></td><td><a href='https://twitter.com/SergDort'>@SergDort</a></td></tr>
       <tr><td>Yuri Karabatov</td><td><a href='https://github.com/karabatov'>@karabatov</a></td><td><a href='https://twitter.com/karabatov'>@karabatov</a></td></tr>
     <tr><td rowspan='5' valign='top'><strong>Native Apps Platform</strong><br/>Engineering work like tooling, CI and development processes.</td>
@@ -72,8 +71,10 @@ The rest of the iOS Engineers work in the following squads:
     <tr><td rowspan='2' valign='top'><strong>Healthcheck</strong><br/>Overview of your health using a 3D body model (avatar).</td>
       <td>Ben Henshall</td><td><a href='https://github.com/Ben-Henshall'>@Ben-Henshall</a></td><td><a href='https://twitter.com/ben_henshall'>@ben_henshall</a></td></tr>
       <tr><td>Julien Ducret</td><td><a href='https://github.com/brocoo'>@brocoo</a></td><td></td></tr>
-    <tr><td rowspan='1' valign='top'><strong>Identity</strong><br/>Authentication and Authorization related work</td>
-      <td></td><td></td><td></td></tr>
+    <tr><td rowspan='3' valign='top'><strong>Identity</strong><br/>Authentication and Authorization related work</td>
+      <td>Giorgos Tsiapaliokas</td><td><a href='https://github.com/gtsiap'>@gtsiap</a></td><td></td></tr>
+      <tr><td>Michael Brown</td><td><a href='https://github.com/mluisbrown'>@mluisbrown</a></td><td><a href='https://twitter.com/mluisbrown'>@mluisbrown</a></td></tr>
+      <tr><td>Vojtech Vrbka</td><td><a href='https://github.com/vojtechvrbka'>@vojtechvrbka</a></td><td><a href='https://twitter.com/vojtechvrbka'>@vojtechvrbka</a></td></tr>
     <tr><td rowspan='5' valign='top'><strong>Monitor</strong><br/>Help members manage and sustain a healthy lifestyle.</td>
       <td>Anders Ha</td><td><a href='https://github.com/andersio'>@andersio</a></td><td><a href='https://twitter.com/_andersha'>@_andersha</a></td></tr>
       <tr><td>Daniel Haight</td><td><a href='https://github.com/Daniel1of1'>@Daniel1of1</a></td><td></td></tr>
@@ -91,10 +92,9 @@ The rest of the iOS Engineers work in the following squads:
       <td>Anil Puttabuddhi</td><td><a href='https://github.com/anilputtabuddhi'>@anilputtabuddhi</a></td><td></td></tr>
     <tr><td rowspan='1' valign='top'><strong>Test Kits</strong><br/>Managing everything related to Babylon do-at-home tests.</td>
       <td>Michał Kwiecień</td><td><a href='https://github.com/MichalTKwiecien'>@MichalTKwiecien</a></td><td><a href='https://twitter.com/kwiecien_co'>@kwiecien_co</a></td></tr>
-    <tr><td rowspan='3' valign='top'><strong>Triage</strong><br/>Chatbot functionality.</td>
+    <tr><td rowspan='2' valign='top'><strong>Triage</strong><br/>Chatbot functionality.</td>
       <td>Danilo Aliberti</td><td><a href='https://github.com/daniloaliberti'>@daniloaliberti</a></td><td></td></tr>
       <tr><td>João Pereira</td><td><a href='https://github.com/NSMyself'>@NSMyself</a></td><td><a href='https://twitter.com/NSMyself'>@NSMyself</a></td></tr>
-      <tr><td>Michael Brown</td><td><a href='https://github.com/mluisbrown'>@mluisbrown</a></td><td><a href='https://twitter.com/mluisbrown'>@mluisbrown</a></td></tr>
     <tr><td rowspan='4' valign='top'><strong>US Professional Services</strong><br/>Features for app in the US.</td>
       <td>Chesley Stephens</td><td><a href='https://github.com/cstephens-babylon'>@cstephens-babylon</a></td><td></td></tr>
       <tr><td>Patrick Westmeyer</td><td><a href='https://github.com/bh-pwestmeyer'>@bh-pwestmeyer</a></td><td></td></tr>

--- a/scripts/squads.yml
+++ b/scripts/squads.yml
@@ -121,6 +121,10 @@ team:
   - &Witold
     name: Witold Skibniewski
     github: mr-v
+  - &Vojtech
+    name: Vojtech Vrbka
+    github: vojtechvrbka
+    twitter: vojtechvrbka
   - &Yuri
     name: Yuri Karabatov
     github: karabatov
@@ -157,7 +161,6 @@ squads:
     desc: General user experience in the app.
     members:
       - *Emese
-      - *Giorgos
       - *Sergey
       - *Yuri
   - name: Native Apps Platform
@@ -180,7 +183,9 @@ squads:
   - name: Identity
     desc: Authentication and Authorization related work
     members:
-      - TBD
+      - *Giorgos
+      - *Michael
+      - *Vojtech
   - name: Monitor
     desc: Help members manage and sustain a healthy lifestyle.
     members:
@@ -215,7 +220,6 @@ squads:
     members:
       - *Danilo
       - *Joao
-      - *Michael
   - name: US Professional Services
     desc: Features for app in the US.
     members:


### PR DESCRIPTION
**Why?**
We have Vojtech who join our team this week.
The Identity squad was not updated with the new engineers working on it.

**How?**
Updating the `squads.yml` file with Vojtech in the engineers list and adding the correct engineers to the Identity squad.
After the update, ran the ruby script to automatically update the readme file.