### PR TITLE
Update slack channels list

### DIFF
--- a/Cookbook/Technical-Documents/NewHiresCheckList.md
+++ b/Cookbook/Technical-Documents/NewHiresCheckList.md
@@ -30,6 +30,8 @@ As an iOS Engineer, you should be in the following Slack channels:
 	- `#ios-questions`
 	- `#ios-sdk`
 	- `#ios-oss`
+	- `#ios-pedia`
+	- `#ios-meeting-outcomes`
 
 * Others
 	- `#demo_frontend`


### PR DESCRIPTION
**Why?**
We've added two important channels that every iOS Engineers should be aware of.

**How**
By updating the list of channels with
#ios-pedia
#ios-meeting-outcomes