### PR TITLE
Notify holidays in team calendar

### DIFF
--- a/Cookbook/Technical-Documents/OutOffOfficeRequest.md
+++ b/Cookbook/Technical-Documents/OutOffOfficeRequest.md
@@ -32,8 +32,8 @@ If there is a big impact in the iOS Team or in your Squad due to you being away,
 #### Steps to Configure the Outlook event
 1. Open Outlook 
 1. Select Calendar
-1. Select Meeting
-1. To: `<iOS calendar email group>`, `<your squad email group>`
+1. In the menu on the left select the iOS team calendar (Please make sure you have the iOS Team calendar added as a shared calendar to your Outlook)
+1. Select Appointment
 1. Subject: `<Your name>` Holidays 🌴
 1. Duration: All-day event
 1. Show as: Free


### PR DESCRIPTION
**Why?**
We should try to disrupt as much as possible the team. When we add events in the calendar to notify the rest of the team of holidays we should try not send notifications.

**How?**
Instead of sending the event to the team calendar we can add the event to the team calendar. This way everyone will have the event visible in their outlook without requiring to accept and to dismiss notifications.