### PR TITLE
[CNSMR-3180] Proposal: Decouple snapshot tests from unit tests

### DIFF
--- a/Cookbook/Proposals/DecoupleSnapshotTestsFromUnitTests.md
+++ b/Cookbook/Proposals/DecoupleSnapshotTestsFromUnitTests.md
@@ -28,4 +28,4 @@ We would also need to create a new scheme like `BabylonUniTestsOnly` which would
 
 ## Alternatives considered
 
-- **Xcode's 11 Test plans** - Unfortunately, I haven't found a way to select test files per configuration. I'm afraid we cannot use test plans.
+- **Xcode's 11 Test plans** - TestPlans won't help us in context of this proposal. We would still need to have 2 tests targets, even if we use test plans. Since TestPlans are not necessary and doesn't make this proposal any simpler, I don't think we should enable them as part of the proposal.

--- a/Cookbook/Proposals/DecoupleSnapshotTestsFromUnitTests.md
+++ b/Cookbook/Proposals/DecoupleSnapshotTestsFromUnitTests.md
@@ -4,13 +4,15 @@
 ## Introduction
 The purpose of this proposal is to decouple snapshot tests from unit tests to be able to run only unit-tests which takes much less time to execute than snapshot tests.
 
+The goal of this proposal is to make it possible to run only unit-tests **locally** in Xcode. Improving CI run time is not a goal of this proposal.
+
 ## Motivation
-Right now when we run all unit-tests (by pressing cmd+U) we also run snapshot tests. Right now it takes **14 minutes**(😱) to run all unit+snapshot tests which is very long.\
+Right now when we run all unit-tests (by pressing cmd+U) we also run snapshot tests. Right now it takes **14 minutes**(😱) to run all unit+snapshot tests which is very long. Unit-tests should run as quickly as possible so we can have a quick feedback about stability of our changes.\
 \
-Ideally, it would be nice to be able to run only snapshot tests when we don't work on UI.
+Ideally, it would be nice to be able to run only unit-tests when we don't work on UI.
 
 ## Proposed solution
-Decouple snapshot tests from unit test by creating SnapshotTest targets in every framework which has snapshots.
+Decouple snapshot tests from unit test by creating `*SnapshotTests` targets in every framework which has snapshots.
 
 We would also need to create a new scheme like `BabylonUniTestsOnly` which would run only tests targets without snapshot tests targets.
 
@@ -24,7 +26,7 @@ We would also need to create a new scheme like `BabylonUniTestsOnly` which would
 
 ## Alternatives considered
 
-- **Xcode's 11 Test plans** - Unfortunately, I haven't found a way to select test files per a configurations. I'm afraid we cannot use test plans.
+- **Xcode's 11 Test plans** - Unfortunately, I haven't found a way to select test files per configuration. I'm afraid we cannot use test plans.
 
 
 

--- a/Cookbook/Proposals/DecoupleSnapshotTestsFromUnitTests.md
+++ b/Cookbook/Proposals/DecoupleSnapshotTestsFromUnitTests.md
@@ -28,4 +28,4 @@ We would also need to create a new scheme like `BabylonUnitTests` which would ru
 
 ## Alternatives considered
 
-- **Xcode's 11 Test plans** - TestPlans won't help us in context of this proposal. We would still need to have 2 tests targets, even if we use test plans. Since TestPlans are not necessary and doesn't make this proposal any simpler, I don't think we should enable them as part of the proposal.
+- **Xcode's 11 Test plans** - TestPlans won't help us in context of this proposal. We would still need to have 2 tests targets, even if we use test plans. Admittedly, TestPlans do have a possibility to include only a subset of tests. unfortunately, when we create a new testfile it would be automatically enabled in every testplan which uses corresponding test target. To exlude snapshot test being run in unit-test TestPlan we would need to manually untick the snapshot in this TestPlan. This is too errorprone and additional manuall step. Since TestPlans are not necessary and doesn't make this proposal any simpler, I don't think we should enable them as part of the proposal.

--- a/Cookbook/Proposals/DecoupleSnapshotTestsFromUnitTests.md
+++ b/Cookbook/Proposals/DecoupleSnapshotTestsFromUnitTests.md
@@ -7,16 +7,16 @@ The purpose of this proposal is to decouple snapshot tests from unit tests to be
 The goal of this proposal is to make it possible to run only unit-tests **locally** in Xcode. Improving CI run time is not a goal of this proposal.
 
 ## Motivation
-Right now when we run all unit-tests (by pressing cmd+U) we also run snapshot tests. Right now it takes **14 minutes** to run all unit+snapshot tests which is very long. Those 14 minutes doesn't include the build time 😱.
+Right now, when we trigger all unit-tests (by pressing cmd+U), the snapshot tests are also run.  It takes **14 minutes** to run all unit+snapshot tests which is very long. Those 14 minutes doesn't include the build time 😱.
 
-Unit-tests should run as quickly as possible so we can have a quick feedback about stability of our changes.\
+Unit-tests should run as quickly as possible, so we can have a quick feedback about our changes that break tests.\
 \
 Ideally, it would be nice to be able to run only unit-tests when we don't work on UI. Unit-tests in separation take about ~2% of the execution time.
 
 ## Proposed solution
 Decouple snapshot tests from unit test by creating `*SnapshotTests` targets in every framework which has snapshots.
 
-We would also need to create a new scheme like `BabylonUniTestsOnly` which would run only tests targets without snapshot tests targets.
+We would also need to create a new scheme like `BabylonUnitTests` which would run only tests targets without snapshot tests targets.
 
 `Babylon` scheme would still remain configuration to run all tests (unit + snapshots).
 

--- a/Cookbook/Proposals/DecoupleSnapshotTestsFromUnitTests.md
+++ b/Cookbook/Proposals/DecoupleSnapshotTestsFromUnitTests.md
@@ -7,9 +7,11 @@ The purpose of this proposal is to decouple snapshot tests from unit tests to be
 The goal of this proposal is to make it possible to run only unit-tests **locally** in Xcode. Improving CI run time is not a goal of this proposal.
 
 ## Motivation
-Right now when we run all unit-tests (by pressing cmd+U) we also run snapshot tests. Right now it takes **14 minutes**(😱) to run all unit+snapshot tests which is very long. Unit-tests should run as quickly as possible so we can have a quick feedback about stability of our changes.\
+Right now when we run all unit-tests (by pressing cmd+U) we also run snapshot tests. Right now it takes **14 minutes** to run all unit+snapshot tests which is very long. Those 14 minutes doesn't include the build time 😱.
+
+Unit-tests should run as quickly as possible so we can have a quick feedback about stability of our changes.\
 \
-Ideally, it would be nice to be able to run only unit-tests when we don't work on UI.
+Ideally, it would be nice to be able to run only unit-tests when we don't work on UI. Unit-tests in separation take about ~2% of the execution time.
 
 ## Proposed solution
 Decouple snapshot tests from unit test by creating `*SnapshotTests` targets in every framework which has snapshots.

--- a/Cookbook/Proposals/DecoupleSnapshotTestsFromUnitTests.md
+++ b/Cookbook/Proposals/DecoupleSnapshotTestsFromUnitTests.md
@@ -1,0 +1,30 @@
+# Decouple Snapshot tests from unit tests
+* Author(s): Adam Borek
+
+## Introduction
+The purpose of this proposal is to decouple snapshot tests from unit tests to be able to run only unit-tests which takes much less time to execute than snapshot tests.
+
+## Motivation
+Right now when we run all unit-tests (by pressing cmd+U) we also run snapshot tests. Right now it takes **14 minutes**(😱) to run all unit+snapshot tests which is very long.\
+\
+Ideally, it would be nice to be able to run only snapshot tests when we don't work on UI.
+
+## Proposed solution
+Decouple snapshot tests from unit test by creating SnapshotTest targets in every framework which has snapshots.
+
+We would also need to create a new scheme like `BabylonUniTestsOnly` which would run only tests targets without snapshot tests targets.
+
+`Babylon` scheme would still remain configuration to run all tests (unit + snapshots).
+
+## Impact on existing codebase
+
+1. We would have more tests targets
+2. Once we create any test file we would need to be cautious to add it to the correct test target. Unit tests into `*Tests`, snapshot tests into `*SnapshotTests`
+3. We would need to have additional scheme like `BabylonUnitTestsOnly` which would run only unit-tests on `cmd+u`.
+
+## Alternatives considered
+
+- **Xcode's 11 Test plans** - Unfortunately, I haven't found a way to select test files per a configurations. I'm afraid we cannot use test plans.
+
+
+

--- a/Cookbook/Proposals/DecoupleSnapshotTestsFromUnitTests.md
+++ b/Cookbook/Proposals/DecoupleSnapshotTestsFromUnitTests.md
@@ -27,6 +27,3 @@ We would also need to create a new scheme like `BabylonUniTestsOnly` which would
 ## Alternatives considered
 
 - **Xcode's 11 Test plans** - Unfortunately, I haven't found a way to select test files per configuration. I'm afraid we cannot use test plans.
-
-
-


### PR DESCRIPTION
On our H2 goal list there is a goal about decoupling snapshot tests from unit tests so we are able to run only unit tests which are much more faster than snapshots.

This is a proposal how this could be implemented. This is a continuation of a quick survey I did on our slack: https://babylonhealth.slack.com/archives/G22EWKXQT/p1574330951269300