### PR TITLE
Update OOO steps for calendar event

### DIFF
--- a/Cookbook/Technical-Documents/OutOffOfficeRequest.md
+++ b/Cookbook/Technical-Documents/OutOffOfficeRequest.md
@@ -38,7 +38,6 @@ If there is a big impact in the iOS Team or in your Squad due to you being away,
 1. Duration: All-day event
 1. Show as: Free
 1. Reminder: None
-1. Request Responses: Off
 1. Hit "Send"
 
 #### Steps to Configure automatic reply


### PR DESCRIPTION
Now that @AnnKatF has changed the process in #272 from creating a meeting with invites to creating an event directly on the calendar instead, the step about having to turn "Request responses" off is not relevant anymore