### PR TITLE
[IOSP-514] [CNSMR-3272] Add detailed documentation about the CRP bot

### DIFF
--- a/Cookbook/README.md
+++ b/Cookbook/README.md
@@ -16,17 +16,18 @@
   - [Code owners](./Proposals/CODEOWNERS.md)
   - [Writing proposals](./Technical-Documents/WritingAProposal.md)
   - Writing Documentation
-  - [Development process](https://github.com/babylonhealth/ios-playbook/blob/master/Cookbook/Technical-Documents/Development-Process.md)
-  - [Jira](https://github.com/babylonhealth/ios-playbook/blob/master/Cookbook/Technical-Documents/JIRA.md)
+  - [Development process](./Technical-Documents/Development-Process.md)
+  - [Jira](./Technical-Documents/JIRA.md)
   - Pull Requests
-  	- [Code review etiquette](https://github.com/babylonhealth/ios-playbook/blob/master/Etiquette/CODE_REVIEW.md)
+  	- [Code review etiquette](../Etiquette/CODE_REVIEW.md)
   	- [How to add Labels to a Pull Request](./Technical-Documents/LabelsInPRs.md)
   	- Merge bot
   - [Release process](./Technical-Documents/ReleaseProcess.md)
+    - [CRP bot](./Technical-Documents/CRP-Bot.md)
   - [Support engineer role](./Technical-Documents/SupportEngineerRole.md)
   - [Chapter meetings](./Technical-Documents/meetings-purpose.md)
   - [External libraries policy](./Technical-Documents/External-libraries.md)
-  - [Code of conduct](https://github.com/babylonhealth/ios-playbook/blob/master/Etiquette/README.md)
+  - [Code of conduct](../Etiquette/README.md)
   - [Requesting and Notifying Out Of Office time](./Technical-Documents/OutOffOfficeRequest.md)
 
 ## Architecture 🗼
@@ -72,11 +73,11 @@
   - CircleCI
 
 ## Recruitment 🎓
-  - [Overview](https://github.com/babylonhealth/ios-playbook/blob/master/Interview/README.md) 🛠
-  - [Software Engineer Technical test](https://github.com/babylonhealth/ios-playbook/blob/master/Interview/demo.md)
-  - [UI Automation Engineer Technical Test](https://github.com/babylonhealth/ios-playbook/blob/master/Interview/AutomationExercise.md)
+  - [Overview](../Interview/README.md) 🛠
+  - [Software Engineer Technical test](../Interview/demo.md)
+  - [UI Automation Engineer Technical Test](../Interview/AutomationExercise.md)
   - Pair programming session
-  - [Technical questions](https://github.com/babylonhealth/ios-playbook/blob/master/Interview/questions.md)
+  - [Technical questions](../Interview/questions.md)
   - Cultural fit questions
   - Interview presentation
 

--- a/Cookbook/README.md
+++ b/Cookbook/README.md
@@ -23,7 +23,7 @@
   	- [How to add Labels to a Pull Request](./Technical-Documents/LabelsInPRs.md)
   	- Merge bot
   - [Release process](./Technical-Documents/ReleaseProcess.md)
-    - [CRP bot: Usage](./Technical-Documents/CRP-Bot.md)
+    - [CRP bot: Usage Documentation](./Technical-Documents/CRP-Bot.md)
     - [CRP bot: Implementation Details](./Technical-Documents/CRP-Bot-ImplementationDetails.md)
   - [Support engineer role](./Technical-Documents/SupportEngineerRole.md)
   - [Chapter meetings](./Technical-Documents/meetings-purpose.md)

--- a/Cookbook/README.md
+++ b/Cookbook/README.md
@@ -23,7 +23,8 @@
   	- [How to add Labels to a Pull Request](./Technical-Documents/LabelsInPRs.md)
   	- Merge bot
   - [Release process](./Technical-Documents/ReleaseProcess.md)
-    - [CRP bot](./Technical-Documents/CRP-Bot.md)
+    - [CRP bot: Usage](./Technical-Documents/CRP-Bot.md)
+    - [CRP bot: Implementation Details](./Technical-Documents/CRP-Bot-ImplementationDetails.md)
   - [Support engineer role](./Technical-Documents/SupportEngineerRole.md)
   - [Chapter meetings](./Technical-Documents/meetings-purpose.md)
   - [External libraries policy](./Technical-Documents/External-libraries.md)

--- a/Cookbook/Technical-Documents/CRP-Bot-ImplementationDetails.md
+++ b/Cookbook/Technical-Documents/CRP-Bot-ImplementationDetails.md
@@ -72,7 +72,7 @@ This whitelist has two main purposes:
 
 Those misconfigured boards are tracked in [IOSP-101](https://babylonpartners.atlassian.net/browse/IOSP-101). 
 
-Trying to execute the CRP automation on those boards would end in an invalid API request or worse, some unexpected changes in the tickets, because field IDs would not match the ones expected by the bot.
+Trying to execute the CRP automation on those boards would end in an invalid API request or worse, some unexpected changes in the tickets, because field IDs would not match the ones expected by the bot. Which is why those boards are not included in the whitelist.
 
 ### `batchSetFixedVersions`
 
@@ -93,6 +93,7 @@ A similar construct is used in `createAndSetFixedVersions` to gather all the rep
 ### SlowClient
 
 One of the particularities of this process is that it sends a **LOT** of API calls to JIRA:
+
 – one for the CRP ticket itself
 - then one for each board to create a JIRA version
 - and, finally, one for each ticket in the CRP in order to update their fields

--- a/Cookbook/Technical-Documents/CRP-Bot-ImplementationDetails.md
+++ b/Cookbook/Technical-Documents/CRP-Bot-ImplementationDetails.md
@@ -1,0 +1,103 @@
+# CRP Implementation Details
+
+One of the command handled by our Babylon Stevenson bot is `/crp`, which aims to create a CRP ticket on JIRA – especially, a specific type of ticket which takes part of our SSDLC (Secure Software Development LifeCycle) process in the company.
+
+This process being quite specific to our SSDLC, we felt like this dedicated documentation would be useful to understand the specifics of this particular command.
+
+## Process description
+
+This part of the SSDLC process consists of the following steps, that our Bots automates:
+
+* Collecting the list of JIRA tickets that will be included as part of the new release.
+  * It does that by gathering the `git log` between the last tag of an app flavor and the newly-open release branch of that same app flavor, extracting the references of JIRA tickets from the commit messages
+* Create a JIRA ticket on our dedicated "CRP" board in our JIRA instance
+  * That ticket should contain the list of links to the JIRA tickets gathered from the previous step, in addition to some other fields
+  * That ticket will later go through the validation process, having to be reviewed and approved before we could consider pushing the new version of the app to the Stores
+* For each JIRA board which has at least one ticket listed in the CRP:
+  * Create a JIRA Release in that board, for the new version about to be released
+  * Set the "Fix Version" field of each ticket of this board appearing in the CRP to that new JIRA release, to flag that this ticket was part of that release.
+
+## Implementation details
+
+### Parsing of the command
+
+This part is implemented in `SlackCommand+CRP.swift`. In the `run` closure of this `SlackCommand` we extract the name of the repo (ios or android) and the release branch name from the command, to get a `RepoMapping`
+and build a `GitHubService.Release` (deduce the app flavor and version from the branch name)
+
+Then this code will:
+
+* Call `github.changelog(…)` to gather the list of commit messages
+* Call `jira.executeCRPTicketProcess` to run the full CRP process using that list of commits and the `Release` object build above
+* Post the CRP ticket URL + the report of potential encountered issues as a message in Slack
+
+### Building the Changelog: `github.changelog(…)`
+
+This part is implemented in `GitHubService+Commits.swift`. It does the following:
+
+* Gather the list of GitHub Releases of the repo, using an API call (`releases(in: repo, on: container)`)
+* Find the one corresponding to the latest tag for the flavor – i.e. the most recent release whose tag is matching `(release|hotfix)/<appname>/*`
+* Gather the list of commit messages between that tag (latest release) and the release branch we are running the CRP process on
+
+This results in an array of commit messages (only using the first line of each commit message) from the last release to the new one
+
+### Executing the CRP process
+
+This is all implemented in `JiraService+CRP,swift`.
+
+The convenience method `executeCRPTicketProcess(…)` is usually the entry point.
+
+* It uses the `document(from [ChangelogSection])` method to build the JIRA document (formatted text field) to be used in the CRP issue we will create
+* It then instantiate a `CRPIssue` model object with all fields properly filled, then make the API call in `create(issue:…, on:…)` to actually create the issue in JIRA
+* then starts the process to create and set the "Fix Versions" field of all tickets via `createAndSetFixedVersions(…)`.
+
+Note that the `CRPIssue` type is a `typealias` for `Issue<CRPIssueFields`. The `Issue<T>` generic type is defined in the bot's `JiraService.swift` file, and is generic to support any custom fields provided for specific type of issues in JIRA.  
+As our CRP board in our JIRA instance uses a lot of custom fields we need to fill, the `CRPIssueFields` structure, being specific to our use case, is declared in `JiraService+CRP.swift` in the app target.
+
+### JIRA `document`
+
+When creating the `CRPIssue` instance (call to `makeCRPIssue(…)`), we need to build the body of the issue descrition from the list of commit messages. This is done by:
+
+* Call `ChangelogSection.makeSections(from: commitMessages, for: release)` to build a `[ChangelogSection]` array from the list of commit messages.
+  * This is done by detecting the JIRA ticket references (`[XXX-NNN]`) within commit messages using a RegEx, and triage those messages based on the JIRA board detected
+* Then call `JiraService.document(from: [ChangeLogSections]` to build a "JIRA document" (a JIRA format representing a formatted text containing headings, bullet points, links, etc)
+
+This method uses helpers like `formatMessageLine` to transform a commit message into a `FieldType.TextArea.ListItem` – aka a model objet representing a bullet point item in the JIRA formatted text.
+
+Those `FieldType.TextArea` subtypes, used to represent various entities in a formatted text (textarea) in JIRA, are all declared in the bot's framework code in `JiraService+FieldTypes.swift`. Conforming to `Content` (which itself inherits from `Codable`), then can then be transformed into JSON when included in the API call to create the CRP ticket.
+
+### `createAndSetFixedVersions`
+
+This method is declared in `JiraService+CRP.swift` and its goal is to iterate over each  `ChangelogSection` (representing a given board with its associated tickets included in the CRP), and for each board/section that is whitelisted in our static `self.knownProjects` list:
+
+* Create an apptly named JIRA release if a release with that name doesn't already exist; otherwise, reuse the existing one
+* Then for each ticket in this `ChangelogSection` (i.e. associated with this board), make an API request to set the `Fix Version` field to this JIRA Release. This is done in `batchSetFixedVersions(…)` and described in the following section
+
+Any section that is not part of the `knownProjects` list (static constant declared in `configure.swift`) will be skipped during this process, i.e. even if the ticket on unknown boards will be included in the CRP ticket's body, there will be no attempt to create a JIRA version on any unknown board nor touch the Fix Version field of those tickets. This whitelist has two main purposes:
+
+1. First to avoid accidentally create releases and touch tickets that are not supposed to be our responsibility and might have been wrongfully detected when parsing the commit messages. For example if a commit message contains a reference to the original ticket but also mentions another ticket from a board we don't own, we don't want to process to detect the latter one and affect the board and ticket we don't own
+2. Another reason is because some boards, even if they are supposed to follow the CRP process, are misconfigured in JIRA and use a custom set of fields and custom process instead of using the same fields and configuration than all the other boards. Trying to execute the CRP automation on those boards would end in an invalid API request or worse, some unexpected changes in the tickets, because field IDs would not match the ones expected by the bot.
+
+### `batchSetFixedVersions`
+
+This method is called for each board by `createAndSetFixedVersions`. It is passed the list of tickets for said board, and the JIRA version reference to set on the `Fix Version` field for these tickets.
+
+It mainly consists of a `map` on all the tickets, making an API call to `setFixVersion(version, for: ticket, …)` on each ticket in turn.
+
+### FixedVersionReport
+
+One particularity of `createAndSetFixedVersions` and `batchSetFixedVersions` is that we don't want any API call failure to interrupt the whole process. Instead, in case of any API failure, we gather the error in a report object and continue to the next ticket.
+
+This report is then printed at the very end of the CRP process (as a reply in Slack) to inform the Release Engineer which ticket failed to have their "Fix Version" field updated, to let them update the tickets manually.
+
+Note: The `FixedVersionReport` struct is used to gather messages. It's implemented such as passing multiple `FixedVersionReport` to its `init` will `flatMap` the messages of them all in a single report, allowing us to use constructs like `map(to: FixedVersionReport.self, on: container, FixedVersionReport.init)` on the parallel sequence of API calls setting the version on each ticket in `batchSetFixedVersions` and use a similar construct in `createAndSetFixedVersions` to gather all the reports on each board/`ChangelogSection` into a single report.
+
+### SlowClient
+
+One of the particularity of this process is that it sends a LOT of API calls to JIRA – one for the CRP ticket itself, then one for each board to create a JIRA version, then one for each ticket in the CRP to update their fields. This made us reach the JIRA max API quota and resulted in some API requests to JIRA sometimes failing with timeout.
+
+To limit that effect, instead of using the standard Vapor Client to send those requests, we are using a `SlowClient` – see `SlowClient.swift` in the bot target – which limits the number of API calls pending at once, to avoid sending all the API requests in parallel but instead send them by batch.
+
+You can see this being used in various API calls implenented in `JiraService.swift` – via a call to `container.make(SlowClient.self)` on which the requests are then being sent.
+
+_Despite that SlowClient, we still have some API calls to JIRA sometimes fail with timeout – failing to reply even after 60s. What seems to happen is that JIRA receives the request, processes it (e.g. it properly set the Fix Version field for the ticket as asked by the API request) but never return a response back to the API call. Which leads to the report mentioning there was a timeout in the request, despite the action being done._
+

--- a/Cookbook/Technical-Documents/CRP-Bot-ImplementationDetails.md
+++ b/Cookbook/Technical-Documents/CRP-Bot-ImplementationDetails.md
@@ -2,22 +2,13 @@
 
 One of the command handled by our Babylon Stevenson bot is `/crp`, which aims to create a CRP ticket on JIRA – especially, a specific type of ticket which takes part of our SSDLC (Secure Software Development LifeCycle) process in the company.
 
-This process being quite specific to our SSDLC, we felt like this dedicated documentation would be useful to understand the specifics of this particular command.
+The **usage documentation** can be found **in [this companion document](CRP-Bot.md)**. Especially, this other document also describes what is the CRP process – including the various steps it is composed of (i.e. gathering tickets, creating CRP, updating Fix Versions).
 
-## Process description
-
-This part of the SSDLC process consists of the following steps, that our Bots automates:
-
-* Collecting the list of JIRA tickets that will be included as part of the new release.
-  * It does that by gathering the `git log` between the last tag of an app flavor and the newly-open release branch of that same app flavor, extracting the references of JIRA tickets from the commit messages
-* Create a JIRA ticket on our dedicated "CRP" board in our JIRA instance
-  * That ticket should contain the list of links to the JIRA tickets gathered from the previous step, in addition to some other fields
-  * That ticket will later go through the validation process, having to be reviewed and approved before we could consider pushing the new version of the app to the Stores
-* For each JIRA board which has at least one ticket listed in the CRP:
-  * Create a JIRA Release in that board, for the new version about to be released
-  * Set the "Fix Version" field of each ticket of this board appearing in the CRP to that new JIRA release, to flag that this ticket was part of that release.
+The rest of this current document will focus on the **implementation details** of this bot.
 
 ## Implementation details
+
+This bot is implemented in Vapor; its code can be found [in the Stevenson repository](https://github.com/babylonhealth/Stevenson)
 
 ### Parsing of the command
 
@@ -46,24 +37,24 @@ This is all implemented in `JiraService+CRP,swift`.
 
 The convenience method `executeCRPTicketProcess(…)` is usually the entry point.
 
-* It uses the `document(from [ChangelogSection])` method to build the JIRA document (formatted text field) to be used in the CRP issue we will create
-* It then instantiate a `CRPIssue` model object with all fields properly filled, then make the API call in `create(issue:…, on:…)` to actually create the issue in JIRA
-* then starts the process to create and set the "Fix Versions" field of all tickets via `createAndSetFixedVersions(…)`.
+* It uses the `document(from [ChangelogSection])` method to build the [JIRA document](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/) (i.e. formatted text representation) to be used in the CRP issue we will create – see below
+* It then instantiates a `CRPIssue` model object with all fields properly filled, and makes the API call in `create(issue:…, on:…)` to actually create the issue in JIRA
+* It then starts the process to create and set the "Fix Versions" field of all tickets via `createAndSetFixedVersions(…)`.
 
 Note that the `CRPIssue` type is a `typealias` for `Issue<CRPIssueFields`. The `Issue<T>` generic type is defined in the bot's `JiraService.swift` file, and is generic to support any custom fields provided for specific type of issues in JIRA.  
 As our CRP board in our JIRA instance uses a lot of custom fields we need to fill, the `CRPIssueFields` structure, being specific to our use case, is declared in `JiraService+CRP.swift` in the app target.
 
 ### JIRA `document`
 
-When creating the `CRPIssue` instance (call to `makeCRPIssue(…)`), we need to build the body of the issue descrition from the list of commit messages. This is done by:
+When creating the `CRPIssue` instance (call to `makeCRPIssue(…)`), we need to build the body of the issue description from the list of commit messages. This is done by:
 
 * Call `ChangelogSection.makeSections(from: commitMessages, for: release)` to build a `[ChangelogSection]` array from the list of commit messages.
   * This is done by detecting the JIRA ticket references (`[XXX-NNN]`) within commit messages using a RegEx, and triage those messages based on the JIRA board detected
-* Then call `JiraService.document(from: [ChangeLogSections]` to build a "JIRA document" (a JIRA format representing a formatted text containing headings, bullet points, links, etc)
+* Then call `JiraService.document(from: [ChangeLogSections]` to build a [JIRA document](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/) (a JIRA representation of formatted text/documents containing headings, bullet points, links, etc)
 
 This method uses helpers like `formatMessageLine` to transform a commit message into a `FieldType.TextArea.ListItem` – aka a model objet representing a bullet point item in the JIRA formatted text.
 
-Those `FieldType.TextArea` subtypes, used to represent various entities in a formatted text (textarea) in JIRA, are all declared in the bot's framework code in `JiraService+FieldTypes.swift`. Conforming to `Content` (which itself inherits from `Codable`), then can then be transformed into JSON when included in the API call to create the CRP ticket.
+Those `FieldType.TextArea` subtypes, used to represent various entities in a formatted text (textarea) in JIRA, are all declared in the bot's framework code in `JiraService+FieldTypes.swift`. Conforming to `Content` (which itself inherits from `Codable`), they can then be transformed into JSON when included in the API call to create the CRP ticket.
 
 ### `createAndSetFixedVersions`
 
@@ -75,7 +66,7 @@ This method is declared in `JiraService+CRP.swift` and its goal is to iterate ov
 Any section that is not part of the `knownProjects` list (static constant declared in `configure.swift`) will be skipped during this process, i.e. even if the ticket on unknown boards will be included in the CRP ticket's body, there will be no attempt to create a JIRA version on any unknown board nor touch the Fix Version field of those tickets. This whitelist has two main purposes:
 
 1. First to avoid accidentally create releases and touch tickets that are not supposed to be our responsibility and might have been wrongfully detected when parsing the commit messages. For example if a commit message contains a reference to the original ticket but also mentions another ticket from a board we don't own, we don't want to process to detect the latter one and affect the board and ticket we don't own
-2. Another reason is because some boards, even if they are supposed to follow the CRP process, are misconfigured in JIRA and use a custom set of fields and custom process instead of using the same fields and configuration than all the other boards. Trying to execute the CRP automation on those boards would end in an invalid API request or worse, some unexpected changes in the tickets, because field IDs would not match the ones expected by the bot.
+2. Another reason is because some boards, even if they are supposed to follow the CRP process, are misconfigured in JIRA and use a custom set of fields and custom process instead of using the same fields and configuration than all the other boards. Those misconfigured boards are tracked in [IOSP-101](https://babylonpartners.atlassian.net/browse/IOSP-101). Trying to execute the CRP automation on those boards would end in an invalid API request or worse, some unexpected changes in the tickets, because field IDs would not match the ones expected by the bot.
 
 ### `batchSetFixedVersions`
 
@@ -95,9 +86,10 @@ Note: The `FixedVersionReport` struct is used to gather messages. It's implement
 
 One of the particularity of this process is that it sends a LOT of API calls to JIRA – one for the CRP ticket itself, then one for each board to create a JIRA version, then one for each ticket in the CRP to update their fields. This made us reach the JIRA max API quota and resulted in some API requests to JIRA sometimes failing with timeout.
 
-To limit that effect, instead of using the standard Vapor Client to send those requests, we are using a `SlowClient` – see `SlowClient.swift` in the bot target – which limits the number of API calls pending at once, to avoid sending all the API requests in parallel but instead send them by batch.
+To reduce that effect, instead of using the standard Vapor HTTP Client to send those requests, we are using a `SlowClient` – see `SlowClient.swift` in the bot target – which limits the number of API calls pending at once, to avoid sending all the API requests in parallel but instead send them in batches.
 
-You can see this being used in various API calls implenented in `JiraService.swift` – via a call to `container.make(SlowClient.self)` on which the requests are then being sent.
+You can see this being used in various API calls implemented in `JiraService.swift` – via a call to `container.make(SlowClient.self)` on which the requests are then being sent.
 
 _Despite that SlowClient, we still have some API calls to JIRA sometimes fail with timeout – failing to reply even after 60s. What seems to happen is that JIRA receives the request, processes it (e.g. it properly set the Fix Version field for the ticket as asked by the API request) but never return a response back to the API call. Which leads to the report mentioning there was a timeout in the request, despite the action being done._
 
+See "[JIRA API Limitations](CRP-Bot.md#jira-api-limitations)" and "[CRP Command Report](CRP-Bot.md#crp-command-report)" paragraphs in the usage documentation for explanation of how the release engineer should react to those limitations and reported errors.

--- a/Cookbook/Technical-Documents/CRP-Bot-ImplementationDetails.md
+++ b/Cookbook/Technical-Documents/CRP-Bot-ImplementationDetails.md
@@ -63,33 +63,46 @@ This method is declared in `JiraService+CRP.swift` and its goal is to iterate ov
 * Create an apptly named JIRA release if a release with that name doesn't already exist; otherwise, reuse the existing one
 * Then for each ticket in this `ChangelogSection` (i.e. associated with this board), make an API request to set the `Fix Version` field to this JIRA Release. This is done in `batchSetFixedVersions(…)` and described in the following section
 
-Any section that is not part of the `knownProjects` list (static constant declared in `configure.swift`) will be skipped during this process, i.e. even if the ticket on unknown boards will be included in the CRP ticket's body, there will be no attempt to create a JIRA version on any unknown board nor touch the Fix Version field of those tickets. This whitelist has two main purposes:
+Any section that is not part of the `knownProjects` list (static constant declared in `configure.swift`) will be skipped during this process. Even though tickets on unknown boards will be included in the CRP ticket's body, there will be no attempt to create a JIRA version on any unknown board nor touch the Fix Version field of those tickets. 
 
-1. First to avoid accidentally create releases and touch tickets that are not supposed to be our responsibility and might have been wrongfully detected when parsing the commit messages. For example if a commit message contains a reference to the original ticket but also mentions another ticket from a board we don't own, we don't want to process to detect the latter one and affect the board and ticket we don't own
-2. Another reason is because some boards, even if they are supposed to follow the CRP process, are misconfigured in JIRA and use a custom set of fields and custom process instead of using the same fields and configuration than all the other boards. Those misconfigured boards are tracked in [IOSP-101](https://babylonpartners.atlassian.net/browse/IOSP-101). Trying to execute the CRP automation on those boards would end in an invalid API request or worse, some unexpected changes in the tickets, because field IDs would not match the ones expected by the bot.
+This whitelist has two main purposes:
+
+1. First, to avoid accidentally creating release and touch tickets that are not supposed to be our responsibility and might have been wrongfully detected when parsing the commit messages. For example if a commit message contains a reference to the original ticket but also mentions another ticket from a board we don't own, we don't want to process the latter one and affect a board and ticket we don't own
+2. Some boards, even if they are supposed to follow the CRP process, are misconfigured in JIRA and use a custom set of fields and custom process instead of using the same fields and configuration than all the other boards. 
+
+Those misconfigured boards are tracked in [IOSP-101](https://babylonpartners.atlassian.net/browse/IOSP-101). 
+
+Trying to execute the CRP automation on those boards would end in an invalid API request or worse, some unexpected changes in the tickets, because field IDs would not match the ones expected by the bot.
 
 ### `batchSetFixedVersions`
 
-This method is called for each board by `createAndSetFixedVersions`. It is passed the list of tickets for said board, and the JIRA version reference to set on the `Fix Version` field for these tickets.
+This method is called for each board by `createAndSetFixedVersions`. It is passed the list of tickets of said board, and the JIRA version reference in order to update the `Fix Version` field for these tickets.
 
-It mainly consists of a `map` on all the tickets, making an API call to `setFixVersion(version, for: ticket, …)` on each ticket in turn.
+It mainly consists of applying `map` on all the tickets, making an API call to `setFixVersion(version, for: ticket, …)` on each ticket in turn.
 
 ### FixedVersionReport
 
 One particularity of `createAndSetFixedVersions` and `batchSetFixedVersions` is that we don't want any API call failure to interrupt the whole process. Instead, in case of any API failure, we gather the error in a report object and continue to the next ticket.
 
-This report is then printed at the very end of the CRP process (as a reply in Slack) to inform the Release Engineer which ticket failed to have their "Fix Version" field updated, to let them update the tickets manually.
+This report is then printed at the very end of the CRP process (as a reply in Slack) to inform the Release Engineer which tickets failed to have their "Fix Version" field updated, to let them update the tickets manually.
 
-Note: The `FixedVersionReport` struct is used to gather messages. It's implemented such as passing multiple `FixedVersionReport` to its `init` will `flatMap` the messages of them all in a single report, allowing us to use constructs like `map(to: FixedVersionReport.self, on: container, FixedVersionReport.init)` on the parallel sequence of API calls setting the version on each ticket in `batchSetFixedVersions` and use a similar construct in `createAndSetFixedVersions` to gather all the reports on each board/`ChangelogSection` into a single report.
+Note: The `FixedVersionReport` struct is used to gather messages. It's implemented such as passing multiple `FixedVersionReport` to its `init` will `flatMap` the messages of them all in a single report, allowing us to use constructs like `map(to: FixedVersionReport.self, on: container, FixedVersionReport.init)` on the parallel sequence of API calls, thus setting the version on each ticket in `batchSetFixedVersions`. 
+
+A similar construct is used in `createAndSetFixedVersions` to gather all the reports on each board/`ChangelogSection` into a single report.
 
 ### SlowClient
 
-One of the particularity of this process is that it sends a LOT of API calls to JIRA – one for the CRP ticket itself, then one for each board to create a JIRA version, then one for each ticket in the CRP to update their fields. This made us reach the JIRA max API quota and resulted in some API requests to JIRA sometimes failing with timeout.
+One of the particularities of this process is that it sends a **LOT** of API calls to JIRA:
+– one for the CRP ticket itself
+- then one for each board to create a JIRA version
+- and, finally, one for each ticket in the CRP in order to update their fields
+
+This made us reach the JIRA max API quota and, therefore, resulted in some API requests to JIRA sometimes failing with timeout.
 
 To reduce that effect, instead of using the standard Vapor HTTP Client to send those requests, we are using a `SlowClient` – see `SlowClient.swift` in the bot target – which limits the number of API calls pending at once, to avoid sending all the API requests in parallel but instead send them in batches.
 
 You can see this being used in various API calls implemented in `JiraService.swift` – via a call to `container.make(SlowClient.self)` on which the requests are then being sent.
 
-_Despite that SlowClient, we still have some API calls to JIRA sometimes fail with timeout – failing to reply even after 60s. What seems to happen is that JIRA receives the request, processes it (e.g. it properly set the Fix Version field for the ticket as asked by the API request) but never return a response back to the API call. Which leads to the report mentioning there was a timeout in the request, despite the action being done._
+_Despite that SlowClient, we still have some API calls to JIRA sometimes fail with timeout – failing to reply even after 60s. What seems to happen is that JIRA receives the request, processes it (e.g. it properly set the Fix Version field for the ticket as asked by the API request) but never return a response, which leads to the report mentioning there was a timeout in the request despite the action being done._
 
-See "[JIRA API Limitations](CRP-Bot.md#jira-api-limitations)" and "[CRP Command Report](CRP-Bot.md#crp-command-report)" paragraphs in the usage documentation for explanation of how the release engineer should react to those limitations and reported errors.
+See "[JIRA API Limitations](CRP-Bot.md#jira-api-limitations)" and "[CRP Command Report](CRP-Bot.md#crp-command-report)" paragraphs in the usage documentation for an explanation of how the release engineer should react to those limitations and reported errors.

--- a/Cookbook/Technical-Documents/CRP-Bot.md
+++ b/Cookbook/Technical-Documents/CRP-Bot.md
@@ -4,7 +4,7 @@
 
 Because we're now certified ISO-13485, our SSDLC and the ISO process requires that we track every changes in the codebase and in each release of each flavor of our apps. This means that we need to track which commits (and which corresponding JIRA tickets) have been included in each version of the apps we push to the stores.
 
-In order to comply with that tracking requirement, every time a version of one of the flavors (Babylon UK, Bupa, Telus, Ascension US, ...) is released to one of the stores (AppStore or PlayStore), and the CRP bot is triggered (either using the Slack command – e.g. `/crp ios release/babylon/4.4.0` – or automatically during release cutoff _(soon)_) to handle that part of the release process, the bot will handle the following tasks:
+In order to comply with that tracking requirement, every time a version of one of the flavors (Babylon UK, Bupa, Telus, Ascension US, ...) is released to one of the stores (AppStore or PlayStore), and the CRP bot is triggered (either automatically during release cutoff, or when using the Slack command – e.g. `/crp ios release/babylon/4.4.0` to trigger it manually if ever needed) to handle that part of the release process, the bot will handle the following tasks:
 
 * Gather the CHANGELOG from the list of tickets/commits that will be included in this upcoming release.
   - The list is built by listing the commits between the current release being cut and the last tag / GitHub release for the same flavor (e.g. between tag `telus/4.4.0` and branch `release/telus/4.5.0`) as described in our SSDLC

--- a/Cookbook/Technical-Documents/CRP-Bot.md
+++ b/Cookbook/Technical-Documents/CRP-Bot.md
@@ -29,11 +29,11 @@ This is why some of the boards are still not whitelisted. This is tracked in [IO
 
 Note that the whitelist only affects the creation of JIRA releases and update of "Fix Version" field on those boards. A link to the tickets will still be included in the description/body of CRP ticket (listing all tickets found in the changelog messages) even for tickets belonging to a non-whitelisted board.
 
-## Running the CRP bot
+## Triggering the CRP bot
 
-Currently, the CRP bot can be triggered by a slack command `/crp <platform> <branch>` (e.g. `/crp ios release/babylon/4.4.0`) in the `#ios-launchpad` slack channel.
+The CRP process is automatically triggered during the release cutoff automation and happens every second Friday alongside the release branch creation.
 
-In the near future, it will likely be automatically triggered by the script doing the release cut every second Friday.
+Note: The CRP bot can also be triggered by a slack command `/crp <platform> <branch>` (e.g. `/crp ios release/babylon/4.4.0`) in the `#ios-launchpad` slack channel, though now that it is automatically triggered during release cutoff, invoking it manually from Slack should not be necessary anymore. [In the future, that Slack command might be updated to allow _updating_ the existing CRP ticket with _new_ tickets added _after_ release cut](https://babylonpartners.atlassian.net/browse/IOSP-532).
 
 ## JIRA API limitations
 

--- a/Cookbook/Technical-Documents/CRP-Bot.md
+++ b/Cookbook/Technical-Documents/CRP-Bot.md
@@ -4,10 +4,10 @@
 
 Because we're now certified ISO-13485, our SSDLC and the ISO process requires that we track every changes in the codebase and in each release of each flavor of our apps. This means that we need to track which commits (and which corresponding JIRA tickets) have been included in each version of the apps we push to the stores.
 
-In order to comply to that tracking requirement, every time a version of one of the flavors (Babylon UK, Bupa. Telus. Ascension US, ...) is released to one of the stores (AppStore or PlayStore), and the CRP bot is triggered (either using the slack command – e.g. /crp ios release/babylon/4.4.0 – or automatically during release cutoff (soon)) to handle that part of the release process, the bot will handle the following tasks:
+In order to comply with that tracking requirement, every time a version of one of the flavors (Babylon UK, Bupa, Telus, Ascension US, ...) is released to one of the stores (AppStore or PlayStore), and the CRP bot is triggered (either using the Slack command – e.g. `/crp ios release/babylon/4.4.0` – or automatically during release cutoff _(soon)_) to handle that part of the release process, the bot will handle the following tasks:
 
 * Gather the CHANGELOG from the list of tickets/commits that will be included in this upcoming release.
-  - The list is built by listing the commits between the current release being cut and the last tag / GitHub release for the same flavor (e.g. between tag "telus/4.4.0" and branch "release/telus/4.5.0") as described in our SSDLC
+  - The list is built by listing the commits between the current release being cut and the last tag / GitHub release for the same flavor (e.g. between tag `telus/4.4.0` and branch `release/telus/4.5.0`) as described in our SSDLC
   - Since each commit is annotated with a reference to the JIRA ticket it is supposed to implement, the list of commits allows to build a list of Jira tickets included in the release
 * Create the ticket on the CRP board, with the CHANGELOG (list of affected tickets) previously built
 * Create a new JIRA version on each board mentioned in the CHANGELOG (e.g. in CNSMR, NRX, AV, APPTS, … boards) and whitelisted in the bot, named like "iOS Babylon 4.3.0" (same name for each version created on each board).
@@ -23,7 +23,7 @@ To avoid accidentally creating JIRA versions on boards others than the ones we o
 * This provides some security against any `[XXX-NNN]` that might be contained in a commit message to reference a JIRA ticket on some board that we don't own (e.g. a ticket from BackEnd), for which we don't want our bot to act
 * This also allows us to not whitelist some of our boards, for which we ideally would want the CRP bot to work on, but which sadly don't use the official JIRA template that the bot expects – which means that they might not have the same fields in their JIRA tickets, or have different field IDs in the JIRA API for some fields (and sending requests to update a given Field ID would mean accidentally update the wrong field)
 
-This is why some of the boards are still currently not whitelisted. This is tracked in [IOSP-101](https://babylonpartners.atlassian.net/browse/IOSP-101)
+This is why some of the boards are still not whitelisted. This is tracked in [IOSP-101](https://babylonpartners.atlassian.net/browse/IOSP-101)
 
 Note that the whitelist only affects the creation of JIRA releases and update of "Fix Version" field on those boards. A link to the tickets will still be included in the description/body of CRP ticket (listing all tickets found in the changelog messages) even for tickets belonging to a non-whitelisted board.
 
@@ -31,7 +31,7 @@ Note that the whitelist only affects the creation of JIRA releases and update of
 
 Currently, the CRP bot can be triggered by a slack command `/crp <platform> <branch>` (e.g. `/crp ios release/babylon/4.4.0`) in the `#ios-launchpad` slack channel.
 
-In a near future, it will likely be automatically triggered by the script doing the release cut every second Friday.
+In the near future, it will likely be automatically triggered by the script doing the release cut every second Friday.
 
 ## JIRA API limitations
 
@@ -49,12 +49,12 @@ Once the CRP command has finished running, it will deliver a report message to i
 Those errors and warnings can include:
 
 * warnings about boards that are not whitelisted. This is not an error (i.e. nothing failed): it is only to remind us that since said board is not in our whitelist of supported boards (see above), no JIRA release was created nor Fix Version field was updated for this board
-  - either this is a misdetected board (e.g. a commit message contained something that ressembled a JIRA ticket but was in fact not a real reference), in which case that warning can be ignored
+  - either this is a misdetected board (e.g. a commit message contained something that resembled a JIRA ticket but was in fact not a real reference), in which case that warning can be ignored
   - or it's a real board (but which is not using the official JIRA issue templates so is not compatible with the bot), in which case the release manager is supposed to create the JIRA versions and update the Fix Version on those tickets manually
 * errors about API timeouts
   – these are reported as `Error setting FixedVersion for <ticket> - ⚠️ [ThrowError.URLError: The operation could not be completed. (NSURLErrorDomain error -1001.)]`
   - those are instances of the JIRA API limitation described in the previous paragraph, when JIRA happen to not reply to some ouf our API requests and make us timeout on them
-  - most often times the request will have been processed by JIRA and the "Fix Version" field would already be correct – it just didn't send the success HTTP response back – so there's nothing to be done; but on occasion the request might not have been processed by JIRA at all, in which case the release managed should update the field manually for those tickets
+  - most often times the request will have been processed by JIRA and the "Fix Version" field would already be correct – it just didn't send the success HTTP response back – so there's nothing to be done; but on occasion the request might not have been processed by JIRA at all, in which case the release manager should update the field manually for those tickets
 
 
 ## Additional Considerations
@@ -79,7 +79,7 @@ Again, this might seem surprising at first, but this is expected and on purpose.
 
 Another impact of that process is that **even features that are gated by a local feature switch** (hardcoded as being turned off in code) and end up still being disabled when we release the app **will still be flagged with the released version in their "Fix Version"**.
 
-This is because – similar to what was described above with the example of unwanted side effects of a US feature on the UK app – the implementation of a feature that is theoretically supposed to be disabled by a feature flag... can accidentally introduce bugs or have some of the code not protected behind the feature flag like it should have been. So since the code is present in the final app anyway – even if it's supposed to be disabled – then the corresponding JIRA ticket will still have the version set in its "Fix Version".
+This is because – similar to what was described above with the example of unwanted side effects of a US feature on the UK app – the implementation of a feature that is theoretically supposed to be disabled by a feature flag can accidentally introduce bugs or have some of the code not protected behind the feature flag like it should have been. So since the code is present in the final app anyway – even if it's supposed to be disabled – the corresponding JIRA ticket will still have the version set in its "Fix Version".
 
 This isn't really an issue in the end since usually we'll end up having a separate ticket to enable the feature switch and the feature in the future. So that new JIRA ticket about turning the feature on will have its own "Fix Version" telling us when it was enabled.
 

--- a/Cookbook/Technical-Documents/CRP-Bot.md
+++ b/Cookbook/Technical-Documents/CRP-Bot.md
@@ -1,0 +1,99 @@
+# CRP Bot
+
+## What is the CRP process and how does the CRP bot work
+
+Because we're now certified ISO-13485, our SSDLC and the ISO process requires that we track every changes in the codebase and in each release of each flavor of our apps. This means that we need to track which commits (and which corresponding JIRA tickets) have been included in each version of the apps we push to the stores.
+
+In order to comply to that tracking requirement, every time a version of one of the flavors (Babylon UK, Bupa. Telus. Ascension US, ...) is released to one of the stores (AppStore or PlayStore), and the CRP bot is triggered (either using the slack command – e.g. /crp ios release/babylon/4.4.0 – or automatically during release cutoff (soon)) to handle that part of the release process, the bot will handle the following tasks:
+
+* Gather the CHANGELOG from the list of tickets/commits that will be included in this upcoming release.
+  - The list is built by listing the commits between the current release being cut and the last tag / GitHub release for the same flavor (e.g. between tag "telus/4.4.0" and branch "release/telus/4.5.0") as described in our SSDLC
+  - Since each commit is annotated with a reference to the JIRA ticket it is supposed to implement, the list of commits allows to build a list of Jira tickets included in the release
+* Create the ticket on the CRP board, with the CHANGELOG (list of affected tickets) previously built
+* Create a new JIRA version on each board mentioned in the CHANGELOG (e.g. in CNSMR, NRX, AV, APPTS, … boards) and whitelisted in the bot, named like "iOS Babylon 4.3.0" (same name for each version created on each board).
+  - If a release with that exact name already exists in a board, the bot will reuse it instead of creating a new one.
+* Add that newly created version to the "Fix Version" field of the tickets found in the CHANGELOG
+
+You can find an example of [a CRP ticket dedicated to an iOS release for Babylon UK 4.4.0 here](https://babylonpartners.atlassian.net/browse/CRP-4578).
+
+## Projects whitelist
+
+To avoid accidentally creating JIRA versions on boards others than the ones we own, or messing with boards that don't follow the same schema/template as the one expected by the bot, the CRP bot has a whitelist of boards on which it will be allowed to create JIRA versions and set Fix Versions fields.
+
+* This provides some security against any `[XXX-NNN]` that might be contained in a commit message to reference a JIRA ticket on some board that we don't own (e.g. a ticket from BackEnd), for which we don't want our bot to act
+* This also allows us to not whitelist some of our boards, for which we ideally would want the CRP bot to work on, but which sadly don't use the official JIRA template that the bot expects – which means that they might not have the same fields in their JIRA tickets, or have different field IDs in the JIRA API for some fields (and sending requests to update a given Field ID would mean accidentally update the wrong field)
+
+This is why some of the boards are still currently not whitelisted. This is tracked in [IOSP-101](https://babylonpartners.atlassian.net/browse/IOSP-101)
+
+Note that the whitelist only affects the creation of JIRA releases and update of "Fix Version" field on those boards. A link to the tickets will still be included in the description/body of CRP ticket (listing all tickets found in the changelog messages) even for tickets belonging to a non-whitelisted board.
+
+## Running the CRP bot
+
+Currently, the CRP bot can be triggered by a slack command `/crp <platform> <branch>` (e.g. `/crp ios release/babylon/4.4.0`) in the `#ios-launchpad` slack channel.
+
+In a near future, it will likely be automatically triggered by the script doing the release cut every second Friday.
+
+## JIRA API limitations
+
+Given some quota limitations with the JIRA API – which makes JIRA not respond to some requests if we send too many requests in parallel – the CRP bot uses some throttling mechanism to only make API calls to set the "Fix Version" field of each ticket by batches, instead of all at once. This improves the behavior of the JIRA API, but that API still sometimes fail with timeout on some requests – often the JIRA server seem to have processed the request and updated the Fix Version field as requested by the API call, but never returns an HTTP response to the client to let it know it succeeded.
+
+Currently, since the default timeout for network requests is 60s, every time JIRA decides not to respond to one of our API requests, that request takes 60s to finally fail. This means that on those occasions, the CRP process can take as much as N minutes where N is the number of timeout failures on which JIRA API decided not to reply to our requests.  
+This can accumulate to quite some time in total before the CRP end up sending the calls for all the tickets for the release (e.g. on some recent invocations it had 20 API calls fail with timeouts, leading to the whole process taking around 20 minutes in total! Despite those requests having been processed by JIRA since the corresponding tickets still had their Fix Version field properly updated…).
+
+This situation is clearly not ideal, but since we don't have much control on the JIRA API failures, and as far as our understanding of this limitation goes, there's not much we can do (other than reducing the timeout) to improve that situation so far.
+
+## CRP command report
+
+Once the CRP command has finished running, it will deliver a report message to indicate if any error or warning occurred during the process.
+
+Those errors and warnings can include:
+
+* warnings about boards that are not whitelisted. This is not an error (i.e. nothing failed): it is only to remind us that since said board is not in our whitelist of supported boards (see above), no JIRA release was created nor Fix Version field was updated for this board
+  - either this is a misdetected board (e.g. a commit message contained something that ressembled a JIRA ticket but was in fact not a real reference), in which case that warning can be ignored
+  - or it's a real board (but which is not using the official JIRA issue templates so is not compatible with the bot), in which case the release manager is supposed to create the JIRA versions and update the Fix Version on those tickets manually
+* errors about API timeouts
+  – these are reported as `Error setting FixedVersion for <ticket> - ⚠️ [ThrowError.URLError: The operation could not be completed. (NSURLErrorDomain error -1001.)]`
+  - those are instances of the JIRA API limitation described in the previous paragraph, when JIRA happen to not reply to some ouf our API requests and make us timeout on them
+  - most often times the request will have been processed by JIRA and the "Fix Version" field would already be correct – it just didn't send the success HTTP response back – so there's nothing to be done; but on occasion the request might not have been processed by JIRA at all, in which case the release managed should update the field manually for those tickets
+
+
+## Additional Considerations
+
+### Impact on "Fix versions" vs app flavors (US/UK/...)
+
+One consequence of that process is that – because we use a monorepo both on Android and iOS (i.e. the codebase is shared amongst all the app flavors for iOS, and similar for Android) – **JIRA tickets that are implementing a feature for one flavor (e.g. Telus or Ascension) will (also) be marked with versions for other flavors (e.g. "iOS Babylon 4.4.0")** which also include that commit
+
+This could be surprising at first, but is in fact totally normal and expected:
+
+* This allows us to track that the commit (and thus changes in the code) that implemented that feature ended up being merged in the develop branch before we cut the release for Babylon UK and thus the code would be included in what ends in the UK app in the stores.
+* This is important to track even if the ticket in question is supposed to only affect the US app, because ISO and SSDLC is about tracking – including being able to locate when a regression has been introduced and in which releases it might have been shipped – and it could happen that the **commit implementing that feature for the US app accidentally had unforeseen side-effect on the UK** app (e.g. changing something in a module that is used by both flavors).
+* Even if that side effect is unintentional, we need to know that it ended up shipped in the UK release. (Even if admittedly in the ideal case the ticket should not have affected the UK release, but bugs and unintended side-effects happen)
+
+Note however that even if a US ticket will be flagged with e.g. "iOS Babylon 4.5.0" (if corresponding PR was merged before the UK 4.5.0 release), it will eventually also be flagged with e.g. the "iOS Ascension 1.1.0" version in JIRA too once it's actually shipped as part of the US release.
+
+This means that a ticket will ultimately end up with multiple versions in its "Fix Versions" field (typically for different flavors and platforms), allowing us to know all the released versions in which the code related to that ticket ended up, even if it was dormant/inactive/disabled for some flavors.
+
+Again, this might seem surprising at first, but this is expected and on purpose.
+
+### Impact on "Fix versions" vs feature flags
+
+Another impact of that process is that **even features that are gated by a local feature switch** (hardcoded as being turned off in code) and end up still being disabled when we release the app **will still be flagged with the released version in their "Fix Version"**.
+
+This is because – similar to what was described above with the example of unwanted side effects of a US feature on the UK app – the implementation of a feature that is theoretically supposed to be disabled by a feature flag... can accidentally introduce bugs or have some of the code not protected behind the feature flag like it should have been. So since the code is present in the final app anyway – even if it's supposed to be disabled – then the corresponding JIRA ticket will still have the version set in its "Fix Version".
+
+This isn't really an issue in the end since usually we'll end up having a separate ticket to enable the feature switch and the feature in the future. So that new JIRA ticket about turning the feature on will have its own "Fix Version" telling us when it was enabled.
+
+Still, this is a behavior to be aware of to understand the real meaning we put behind that "Fix Version" field (i.e. "the code implementing this feature ended up in the codebase shipped on the store for this version, even if supposedly disabled").
+
+### "Fix versions" and planning versions ahead
+
+Some teams might want to use JIRA versions to plan ahead, at the beginning of a sprint, which tickets we hope to be part of which version.
+
+But since there's no guarantee that those tickets will make it in time in the planned release when the corresponding release branch is cut, it would lead to inconsistencies to use the Fix Version and JIRA releases named `"<platform> <app> <version>"` to mark those planned tickets before the release is cut; because if those planned tickets end up not making the cut, you'd still have manually marked them with a Fix Version that is supposed to reflect what was _actually_ shipped as part of the release.
+
+> Note that for each board, if a Jira version with the exact same name the bots is planning to use ("<Platform> <Flavor> <Version>" e.g. "iOS Ascension 1.1.0") already exists in the Jira board by the time the CRP process is run (= at the time the release branch is cut and the release process starts every second Friday), then the bot will re-use that existing Jira version instead of creating a separate one (Jira doesn't allow two versions to have the same name anyway)
+
+So for teams which want to use JIRA releases and some field to mark tickets _planned_ for that release ahead of time (e.g. at the beginning of the sprint), to avoid inconsistencies between what the bot uses for "tickets actually shipped" and what you use for "tickets hoping to make the cut", we suggest one of those two solutions:
+
+ * either use the "Affects Versions" JIRA field to plan ahead instead of the "Fix Version" field ("Affects Versions" is totally untouched by the bot and is free for PMs to use as they prefer)
+ * or still use the "Fix Versions" to add Jira Versions to a ticket manually, but use Jira Versions names that don't conflict and are clearly distinct from the Jira versions created/managed by the bot. A typical example of that which some squads already use is to name your manually-managed version like "<Platform> <Flavor> RC <Version>" using "RC" in the name to mean Release Candidate and what's planned, and differentiate from the actual version used once actually released.

--- a/Cookbook/Technical-Documents/CRP-Bot.md
+++ b/Cookbook/Technical-Documents/CRP-Bot.md
@@ -39,8 +39,8 @@ In the near future, it will likely be automatically triggered by the script doin
 
 Given some quota limitations with the JIRA API – which makes JIRA not respond to some requests if we send too many requests in parallel – the CRP bot uses some throttling mechanism to only make API calls to set the "Fix Version" field of each ticket by batches, instead of all at once. This improves the behavior of the JIRA API, but that API still sometimes fail with timeout on some requests – often the JIRA server seem to have processed the request and updated the Fix Version field as requested by the API call, but never returns an HTTP response to the client to let it know it succeeded.
 
-Currently, since the default timeout for network requests is 60s, every time JIRA decides not to respond to one of our API requests, that request takes 60s to finally fail. This means that on those occasions, the CRP process can take as much as N minutes where N is the number of timeout failures on which JIRA API decided not to reply to our requests.  
-This can accumulate to quite some time in total before the CRP end up sending the calls for all the tickets for the release (e.g. on some recent invocations it had 20 API calls fail with timeouts, leading to the whole process taking around 20 minutes in total! Despite those requests having been processed by JIRA since the corresponding tickets still had their Fix Version field properly updated…).
+As of January 2020, since the default timeout for network requests is 60s, every time JIRA decides not to respond to one of our API requests, that request takes 60s to finally fail. This means that on those occasions, the CRP process can take as much as N minutes where N is the number of timeout failures on which JIRA API decided not to reply to our requests.  
+This can accumulate to quite some time in total before the CRP ends up sending the calls for all the tickets for the release (e.g. on some recent invocations it had 20 API calls fail with timeouts, leading to the whole process taking around **20 minutes in total** in spite of those requests having been processed by JIRA since the corresponding tickets still had their Fix Version field properly updated…).
 
 This situation is clearly not ideal, but since we don't have much control on the JIRA API failures, and as far as our understanding of this limitation goes, there's not much we can do (other than reducing the timeout) to improve that situation so far.
 
@@ -55,7 +55,7 @@ Those errors and warnings can include:
   - or it's a real board (but which is not using the official JIRA issue templates so is not compatible with the bot), in which case the release manager is supposed to create the JIRA versions and update the Fix Version on those tickets manually
 * errors about API timeouts
   – these are reported as `Error setting FixedVersion for <ticket> - ⚠️ [ThrowError.URLError: The operation could not be completed. (NSURLErrorDomain error -1001.)]`
-  - those are instances of the JIRA API limitation described in the previous paragraph, when JIRA happen to not reply to some ouf our API requests and make us timeout on them
+  - those are instances of the JIRA API limitation described in the previous paragraph, when JIRA happens not to reply to some ouf our API requests and times out
   - most often times the request will have been processed by JIRA and the "Fix Version" field would already be correct – it just didn't send the success HTTP response back – so there's nothing to be done; but on occasion the request might not have been processed by JIRA at all, in which case the release manager should update the field manually for those tickets
 
 

--- a/Cookbook/Technical-Documents/CRP-Bot.md
+++ b/Cookbook/Technical-Documents/CRP-Bot.md
@@ -89,13 +89,11 @@ Still, this is a behavior to be aware of to understand the real meaning we put b
 
 ### "Fix versions" and planning versions ahead
 
-Some teams might want to use JIRA versions to plan ahead, at the beginning of a sprint, which tickets we hope to be part of which version.
+Some squads might want to use JIRA releases to plan ahead, at the beginning of a sprint, which tickets they hope to be part of a future release.
 
-But since there's no guarantee that those tickets will make it in time in the planned release when the corresponding release branch is cut, it would lead to inconsistencies to use the Fix Version and JIRA releases named `"<platform> <app> <version>"` to mark those planned tickets before the release is cut; because if those planned tickets end up not making the cut, you'd still have manually marked them with a Fix Version that is supposed to reflect what was _actually_ shipped as part of the release.
+Since there's no guarantee that those tickets will actually make it in time in the planned release when the corresponding release branch is cut, we need to differentiate a ticket that is just _planned_ from a ticket that _actually made that release_.
 
-> Note that for each board, if a Jira version with the exact same name the bots is planning to use ("<Platform> <Flavor> <Version>" e.g. "iOS Ascension 1.1.0") already exists in the Jira board by the time the CRP process is run (= at the time the release branch is cut and the release process starts every second Friday), then the bot will re-use that existing Jira version instead of creating a separate one (Jira doesn't allow two versions to have the same name anyway)
+As JIRA releases handled by the CRP bot are dedicated to mark tickets that _actually shipped_ in a release (i.e. that are in the corresponding release branch), **you should never use those `"<platform> <app> <version>"` JIRA releases to mark planned tickets** via the `Fix Version` field. Otherwise that will mess up with our SSDLC requirement about tracking which tickets actually shipped with which version.
 
-So for teams which want to use JIRA releases and some field to mark tickets _planned_ for that release ahead of time (e.g. at the beginning of the sprint), to avoid inconsistencies between what the bot uses for "tickets actually shipped" and what you use for "tickets hoping to make the cut", we suggest one of those two solutions:
-
- * either use the "Affects Versions" JIRA field to plan ahead instead of the "Fix Version" field ("Affects Versions" is totally untouched by the bot and is free for PMs to use as they prefer)
- * or still use the "Fix Versions" to add Jira Versions to a ticket manually, but use Jira Versions names that don't conflict and are clearly distinct from the Jira versions created/managed by the bot. A typical example of that which some squads already use is to name your manually-managed version like "<Platform> <Flavor> RC <Version>" using "RC" in the name to mean Release Candidate and what's planned, and differentiate from the actual version used once actually released.
+Instead, you should use JIRA Versions with a name that doesn't conflict with the ones used by the bot.  
+We recommend naming those JIRA releases for _planned_ roadmaps something like **"<Platform> <Flavor> RC <Version>"** – e.g. "iOS Babylon RC 4.10.0". "RC" here meaning "Release Candidate", it will help differentiate that kind of planned JIRA versions from the version used by the bot when the ticket is actually released.

--- a/Cookbook/Technical-Documents/CRP-Bot.md
+++ b/Cookbook/Technical-Documents/CRP-Bot.md
@@ -16,6 +16,8 @@ In order to comply with that tracking requirement, every time a version of one o
 
 You can find an example of [a CRP ticket dedicated to an iOS release for Babylon UK 4.4.0 here](https://babylonpartners.atlassian.net/browse/CRP-4578).
 
+> Note: for documentation about how the CRP is _implemented_ in the code of our Stevenson bot, see [this companion document](CRP-Bot-ImplementationDetails.md)._
+
 ## Projects whitelist
 
 To avoid accidentally creating JIRA versions on boards others than the ones we own, or messing with boards that don't follow the same schema/template as the one expected by the bot, the CRP bot has a whitelist of boards on which it will be allowed to create JIRA versions and set Fix Versions fields.

--- a/Cookbook/Technical-Documents/CRP-Bot.md
+++ b/Cookbook/Technical-Documents/CRP-Bot.md
@@ -8,11 +8,11 @@ In order to comply with that tracking requirement, every time a version of one o
 
 * Gather the CHANGELOG from the list of tickets/commits that will be included in this upcoming release.
   - The list is built by listing the commits between the current release being cut and the last tag / GitHub release for the same flavor (e.g. between tag `telus/4.4.0` and branch `release/telus/4.5.0`) as described in our SSDLC
-  - Since each commit is annotated with a reference to the JIRA ticket it is supposed to implement, the list of commits allows to build a list of Jira tickets included in the release
+  - Since each commit is annotated with a reference to the JIRA ticket it is supposed to implement, the list of commits allows to build a list of JIRA tickets included in the release
 * Create the ticket on the CRP board, with the CHANGELOG (list of affected tickets) previously built
-* Create a new JIRA version on each board mentioned in the CHANGELOG (e.g. in CNSMR, NRX, AV, APPTS, … boards) and whitelisted in the bot, named like "iOS Babylon 4.3.0" (same name for each version created on each board).
+* Create a new JIRA release on each board mentioned in the CHANGELOG (e.g. in CNSMR, NRX, AV, APPTS, … boards) and whitelisted in the bot. It will name it like "iOS Babylon 4.3.0" (it will use the same name for each release created on each JIRA board).
   - If a release with that exact name already exists in a board, the bot will reuse it instead of creating a new one.
-* Add that newly created version to the "Fix Version" field of the tickets found in the CHANGELOG
+* Add that newly created JIRA release to the "Fix Version" field of the tickets found in the CHANGELOG
 
 You can find an example of [a CRP ticket dedicated to an iOS release for Babylon UK 4.4.0 here](https://babylonpartners.atlassian.net/browse/CRP-4578).
 
@@ -20,7 +20,7 @@ You can find an example of [a CRP ticket dedicated to an iOS release for Babylon
 
 ## Projects whitelist
 
-To avoid accidentally creating JIRA versions on boards others than the ones we own, or messing with boards that don't follow the same schema/template as the one expected by the bot, the CRP bot has a whitelist of boards on which it will be allowed to create JIRA versions and set Fix Versions fields.
+To avoid accidentally creating JIRA releases on boards others than the ones we own, or messing with boards that don't follow the same schema/template as the one expected by the bot, the CRP bot has a whitelist of boards on which it will be allowed to create JIRA releases and set Fix Versions fields.
 
 * This provides some security against any `[XXX-NNN]` that might be contained in a commit message to reference a JIRA ticket on some board that we don't own (e.g. a ticket from BackEnd), for which we don't want our bot to act
 * This also allows us to not whitelist some of our boards, for which we ideally would want the CRP bot to work on, but which sadly don't use the official JIRA template that the bot expects – which means that they might not have the same fields in their JIRA tickets, or have different field IDs in the JIRA API for some fields (and sending requests to update a given Field ID would mean accidentally update the wrong field)
@@ -37,7 +37,7 @@ In the near future, it will likely be automatically triggered by the script doin
 
 ## JIRA API limitations
 
-Given some quota limitations with the JIRA API – which makes JIRA not respond to some requests if we send too many requests in parallel – the CRP bot uses some throttling mechanism to only make API calls to set the "Fix Version" field of each ticket by batches, instead of all at once. This improves the behavior of the JIRA API, but that API still sometimes fail with timeout on some requests – often the JIRA server seem to have processed the request and updated the Fix Version field as requested by the API call, but never returns an HTTP response to the client to let it know it succeeded.
+Given some quota limitations with the JIRA API – which makes JIRA not respond to some requests if we send too many requests in parallel – the CRP bot uses some throttling mechanism to only make API calls to set the "Fix Version" field of each ticket by batches, instead of all at once. This improves the behavior of the JIRA API, but that API still sometimes fail with timeout on some requests. Often the JIRA server seem to still have processed those requests and updated the Fix Version field as requested by the API call, but just didn't return the HTTP response to the client to let it know it succeeded.
 
 As of January 2020, since the default timeout for network requests is 60s, every time JIRA decides not to respond to one of our API requests, that request takes 60s to finally fail. This means that on those occasions, the CRP process can take as much as N minutes where N is the number of timeout failures on which JIRA API decided not to reply to our requests.  
 This can accumulate to quite some time in total before the CRP ends up sending the calls for all the tickets for the release (e.g. on some recent invocations it had 20 API calls fail with timeouts, leading to the whole process taking around **20 minutes in total** in spite of those requests having been processed by JIRA since the corresponding tickets still had their Fix Version field properly updated…).
@@ -95,5 +95,5 @@ Since there's no guarantee that those tickets will actually make it in time in t
 
 As JIRA releases handled by the CRP bot are dedicated to mark tickets that _actually shipped_ in a release (i.e. that are in the corresponding release branch), **you should never use those `"<platform> <app> <version>"` JIRA releases to mark planned tickets** via the `Fix Version` field. Otherwise that will mess up with our SSDLC requirement about tracking which tickets actually shipped with which version.
 
-Instead, you should use JIRA Versions with a name that doesn't conflict with the ones used by the bot.  
-We recommend naming those JIRA releases for _planned_ roadmaps something like **"<Platform> <Flavor> RC <Version>"** – e.g. "iOS Babylon RC 4.10.0". "RC" here meaning "Release Candidate", it will help differentiate that kind of planned JIRA versions from the version used by the bot when the ticket is actually released.
+Instead, you should use JIRA releases with a name that doesn't conflict with the ones used by the bot.  
+We recommend naming those JIRA releases for _planned_ roadmaps something like **"<Platform> <Flavor> RC <Version>"** – e.g. "iOS Babylon RC 4.10.0". "RC" here meaning "Release Candidate", it will help differentiate that kind of planned JIRA releases from the JIRA release used by the bot when the ticket is actually released.


### PR DESCRIPTION
Tickets:

* https://babylonpartners.atlassian.net/browse/IOSP-514
* https://babylonpartners.atlassian.net/browse/CNSMR-3272

This is a complement to the PR updating documentation to Stevenson's README (https://github.com/babylonhealth/Stevenson/pull/46)
 * [Documentation in the Stevenson repo](https://github.com/babylonhealth/Stevenson/pull/46) focuses on the global documentation of Stevenson as an OSS framework, for non-Babylonians. It also introduces some light explanations of what commands we implemented for our instance of the bot for Babylon
 * This documentation in the playbook is focused on things specific to Babylon about the bot: the usage side of that bot – why it exists, how it works and what it does, etc – and the implementation details of the CRP command (which is very specific to Babylon SSDLC).

