### PR TITLE
[IOSP-515] [CNSMR-3231] Fix MergeBot link to link to WallE

### DIFF
--- a/Cookbook/README.md
+++ b/Cookbook/README.md
@@ -21,7 +21,7 @@
   - Pull Requests
   	- [Code review etiquette](../Etiquette/CODE_REVIEW.md)
   	- [How to add Labels to a Pull Request](./Technical-Documents/LabelsInPRs.md)
-  	- Merge bot
+  	- [Merge bot](https://github.com/babylonhealth/Wall-E/blob/master/README.md)
   - [How to deal with Localizations](./Technical-Documents/Localizations.md)
   - [Release process](./Technical-Documents/ReleaseProcess.md)
   - [Support engineer role](./Technical-Documents/SupportEngineerRole.md)


### PR DESCRIPTION
Documentation for day-to-day usage is in ios repo, but is private.

So I'm linking to the repo's README instead (which has [a pending PR to improve its README a lot](https://github.com/babylonhealth/Wall-E/pull/52))