### PR TITLE
Added CircleCI config path to Slack CI Integration doc

### DIFF
--- a/Cookbook/Technical-Documents/SlackCIIntegration.md
+++ b/Cookbook/Technical-Documents/SlackCIIntegration.md
@@ -69,7 +69,7 @@ Tip: `/crp help` will respond with instructions for this command.
 
 * #### `/stevenson`
 
-This command will run arbitrary workflow defined in our CircleCI configuration. You can provide a branch parameter to run workflow on a branch unless workflow is configured to be run on specific branches (i.e. only on develop or release branches)
+This command will run arbitrary workflow defined in our CircleCI configuration (`.circleci/config.yml` in the project directory). You can provide a branch parameter to run workflow on a branch unless workflow is configured to be run on specific branches (i.e. only on develop or release branches)
 
 ```
 /stevenson ui_tests branch:develop


### PR DESCRIPTION
Small edit to include the path for the CircleCI config file. Should be useful for those trying to find the file to see what happens when Stevenson runs a command.