### PR TITLE
Update release process document

### DIFF
--- a/Cookbook/Technical-Documents/ReleaseProcess.md
+++ b/Cookbook/Technical-Documents/ReleaseProcess.md
@@ -61,7 +61,7 @@ During this stage, the **release manager** has the following tasks:
 
 1. Testers will then begin their work against the build you just created.
 1. Any hotfix should target the release branch first.
-1. These PRs need to be reviewed by the relevant squad or platform QA (Bibin Paul) & one of the release engineers assigned to the release. This is to ensure visibility of changes being requested to be made, and to ensure the correct builds are available for validation.
+1. These PRs need to be reviewed by the relevant squad or **platform QA** & one of the **release engineers** assigned to the release. This is to ensure visibility of changes being requested to be made, and to ensure the correct builds are available for validation.
     * Bear in mind that two approvals from other engineers assigned by Pull Assigners is not enough in this particular case.
     * After fix is merged to release branch, the automation will create "Cherry pick 🍒" PR targeting `develop`. If no PR gets created, open PR manually and notify Platform squad about the issue with automation. Following this process will ensure that both branches are up to date and reduces the risk of conflicts when merging the release branch back to `develop`.
     * The issue for the hotfix has to visible on the release JIRA board. To ensure this set the release number in `Fix version` in the hotfix's JIRA card.

--- a/Cookbook/Technical-Documents/ReleaseProcess.md
+++ b/Cookbook/Technical-Documents/ReleaseProcess.md
@@ -47,7 +47,7 @@ There are usually two release engineers working at any given time. It goes witho
   1. On the sidebar click `+ Version or Platform` and select `iOS`.
   1. Input the new version number.
     
-During this stage, the release manager has the following tasks:
+During this stage, the **release manager** has the following tasks:
 
   1. Ensure the CRP ticket is up-to-date
      * The CRP ticket is created automatically for iOS during release cutoff ([see details here](https://github.com/babylonhealth/babylon-ios/blob/develop/Documentation/Process/Release%20process/CRP-Bot.md))

--- a/Cookbook/Technical-Documents/ReleaseProcess.md
+++ b/Cookbook/Technical-Documents/ReleaseProcess.md
@@ -8,7 +8,7 @@
 1. Own the entire release process (step-by-step).
 2. Provide visibility of the release, at all stages, to the wider audience (e.g. squad, tribe and iOS chapter lead) by:
 	1. Tagging in the release Slack channel, anyone (Engineers, PMs, QAs) that is relevant to the release and to the issues that are raised during the release cycle.
-	2. Adding in the #ios-standup, a daily note with the status of the release (QA and bug fixing progress).
+	2. Adding in the release channel a daily note with the status of the release (QA and bug fixing progress).
 3. Collaborate with QA by:
     1. Providing visibility to potential blockers to the wider audience.
     2. Escalating abnormal influx of bugs, so the release, as a whole, can be reassessed.

--- a/Cookbook/Technical-Documents/ReleaseProcess.md
+++ b/Cookbook/Technical-Documents/ReleaseProcess.md
@@ -105,7 +105,7 @@ During this stage, the **release manager** has the following tasks:
       ```
       git log --format="%<(25)%an | %s" origin/develop..origin/release/babylon/4.15.0 | grep -vE "^(Steve|iOS Bot) *\|" | sort
       ```
-      (be sure to `git fetch origin master` before that to have up-to-date branches)
+      (be sure to `git fetch origin develop` before that to have up-to-date branches)
 1. Update this document if any steps during the release process have changed.
 
 ## 3. SDK Release

--- a/Cookbook/Technical-Documents/ReleaseProcess.md
+++ b/Cookbook/Technical-Documents/ReleaseProcess.md
@@ -20,7 +20,7 @@
 
 **The objective is to ship the release build as soon as possible whilst maintaining the quality bar and addressing every bug raised by QA**.
 
-When dealing with a particularly complicated bug (one that would require a rather significant effort to address) the release engineer should speak with either Andreea Papillon (Native Apps' Product Manager) or Lilla Szulyovszky (Native Apps' Delivery Manager) as every release is managed and signed-off by the Native Apps squad.  
+When dealing with a particularly complicated bug (one that would require a rather significant effort to address) the release engineer should speak with Release Manager.  
 The bug's corresponding feature should be disabled altogether using its feature switch (if applicable). Such a bug would subsequently be handled by its respective squad.
 
 Release duties have priority over regular squad duties. Please inform your squad of your unavailability before starting to work in the release. As with every other week, twenty percent of your work hours overall are to be allocated towards making the release a reality.

--- a/Cookbook/Technical-Documents/ReleaseProcess.md
+++ b/Cookbook/Technical-Documents/ReleaseProcess.md
@@ -60,14 +60,11 @@ During this stage, the **release manager** has the following tasks:
 *It starts after the App Center build has been delivered and it can take several cycles*
 
 1. Testers will then begin their work against the build you just created.
-1. Any hotfix should target the `develop` branch first.
-1. These PRs need to be reviewed by the relevant squad or platform QA (Bibin Paul) & one of the release engineers assigned to the release. This is to ensure visibility of changes being requested to be made, and to ensure the correct builds are available for validation. The exception being that if an issue is not reproducible on `develop` then we can merge directly with `release`. Still, it should be fully understandable why it is not reproducible to help ensure there is no regression for the next release.
+1. Any hotfix should target the release branch first.
+1. These PRs need to be reviewed by the relevant squad or platform QA (Bibin Paul) & one of the release engineers assigned to the release. This is to ensure visibility of changes being requested to be made, and to ensure the correct builds are available for validation.
     * Bear in mind that two approvals from other engineers assigned by Pull Assigners is not enough in this particular case.
-    * After merging, we'll need to merge these changes to the release branch. This can be done either via cherry-picking the relevant commits or rebasing the PR branch on the release branch. _This should be done by the author of the change and the PR should be reviewed by the release engineer as well_. Doing this will ensure that both branches are up to date and reduces the risk of conflicts when merging the release branch back to develop.
-
-    _Important: do not change the target branch of the PR from develop to release as this increases the risk of bringing in unneeded changes from develop to release branch. Instead create a second PR to release using rebase or cherry-pick and ensure that only required changes are commited._
-
-    * Furthermore, the issue for the hotfix has to be added to the release JIRA board. This can be done automatically by setting the release number in `Fix version` in the hotfix's JIRA card.
+    * After fix is merged to release branch, the automation will create "Cherry pick 🍒" PR targeting `develop`. If no PR gets created, open PR manually and notify Platform squad about the issue with automation. Following this process will ensure that both branches are up to date and reduces the risk of conflicts when merging the release branch back to `develop`.
+    * The issue for the hotfix has to visible on the release JIRA board. To ensure this set the release number in `Fix version` in the hotfix's JIRA card.
 
 ### Phase 4: Submit TestFlight builds to App Store Connect
 *It starts after all opened issues had been adressed and can take several cycles until QA's approval*

--- a/Cookbook/Technical-Documents/ReleaseProcess.md
+++ b/Cookbook/Technical-Documents/ReleaseProcess.md
@@ -98,7 +98,7 @@ During this stage, the **release manager** has the following tasks:
 1. Merge `release` branch back to `develop`:
 	* Open the Release PR ( PR from `release` branch targeting `develop`) which has been automatically created.
   * Resolve the conflicts (if any).
-	* In case there are any changes besides updates to app and build versions, then assign as reviewers all the engineers who worked on those changes and remove the ones automatically assigned by PullAssigners. After merging with `develop` the extra changes may be there due to either resolving conflict or because hot fix PR wasn't merged to `develop`.
+	*  In case there are changes other than updates to app and build versions after merging the changes from `develop`, the release engineer should assign as reviewers all the engineers who worked on those changes and remove the ones automatically assigned by PullAssigners. In current workflow every change integrated to release branch is supposed to be go into to `develop` soon after, so differences should be minimal. Any differences might be a result of resolving conflicts or a hot fix PR not being merged previously to `develop`.
 	* Set the _Merge_ label once all the required reviewers have approved it.
 1. Update the [release calendar](#release-calendar)
 	* Tip: You can use the following command in your Terminal to list the tickets and authors who participated in the Release, to ask them the time they took for each ticket

--- a/Cookbook/Technical-Documents/ReleaseProcess.md
+++ b/Cookbook/Technical-Documents/ReleaseProcess.md
@@ -97,9 +97,8 @@ During this stage, the **release manager** has the following tasks:
    * Attach the zipped `xcarchive` as an artefact to the GitHub release (if you're using the automated release command, you can find the `*.xcarchive.zip` in the Artifacts top section in the CI build).
 1. Merge `release` branch back to `develop`:
 	* Open the Release PR ( PR from `release` branch targeting `develop`) which has been automatically created.
-  * Resolve the conflicts (if any)
-	* Set as reviewers all the engineers who contributed to the `release` branch, and remove the ones automatically assigned by PullAssigners.
-	* Remove from reviewers list any engineer that has been added by the PullAssigner but haven't contributed to the release branch.
+  * Resolve the conflicts (if any).
+	* In case there are any changes besides updates to app and build versions, then assign as reviewers all the engineers who worked on those changes and remove the ones automatically assigned by PullAssigners. After merging with `develop` the extra changes may be there due to either resolving conflict or because hot fix PR wasn't merged to `develop`.
 	* Set the _Merge_ label once all the required reviewers have approved it.
 1. Update the [release calendar](#release-calendar)
 	* Tip: You can use the following command in your Terminal to list the tickets and authors who participated in the Release, to ask them the time they took for each ticket

--- a/Cookbook/Technical-Documents/ReleaseProcess.md
+++ b/Cookbook/Technical-Documents/ReleaseProcess.md
@@ -103,7 +103,7 @@ During this stage, the **release manager** has the following tasks:
 1. Update the [release calendar](#release-calendar)
 	* Tip: You can use the following command in your Terminal to list the tickets and authors who participated in the Release, to ask them the time they took for each ticket
       ```
-      git log --format="%<(25)%an | %s" origin/develop..origin/release/babylon/4.15.0 | grep -vE "^(Steve|iOS Bot) *\|" | sort
+      git log --format="%<(25)%an | %s" origin/develop..origin/release/{flavor}/{version} | grep -vE "^(Steve|iOS Bot) *\|" | sort
       ```
       (be sure to `git fetch origin develop` before that to have up-to-date branches)
 1. Update this document if any steps during the release process have changed.


### PR DESCRIPTION
Some of the information in the release process wasn't up to date. Updates:

- Remove reference to ios-standup 562a0d3
- Update point of contact for dealing with complicated issues 42ceb0a
- Highlight that instructions are for manager 730ca99
- Update process for integrating hotfixes d783d4a
- Update info about reviewing changes after updating release branch with develop 83b42b1
- Reference develop branch in "Update the release calendar" tip. 4ad1e25