### PR TITLE
[Documentation] Add link to Slack document

### DIFF
--- a/Cookbook/README.md
+++ b/Cookbook/README.md
@@ -6,7 +6,7 @@
   - Team Roles
   - Team Structure
   - [Tools and Services](./Technical-Documents/ToolsAndServices.md)
-  - Slack
+  - [How to use Slack](./Technical-Documents/How to use Slack?.md)
   - [GitHub Access](./Technical-Documents/NewHiresCheckList.md#github-access)
   - [Computer set-up](./Technical-Documents/NewHiresCheckList.md#install-prerequisites)
   - [Initial tasks](./Technical-Documents/NewHiresCheckList.md#whats-next)


### PR DESCRIPTION
**Why?**
The link to the Slack document was missing.

**How?**
Linking the Slack document.