### PR TITLE
[IOSP-607] Update CODEOWNERS file to invite the ios-dev team for reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Global rule for the whole codebase. Every PR needs to be reviewed by at least one permanent team member.
-# This empty team will act as a proxy for the PullAssigner bot. When a new PR arrives, PullAssigner will be triggered,
-# which will then pick members from the iOS-Admin team
-* @babylonhealth/iOS-PullAssigner
+# When a new PR arrives, GitHub auto reviewer assignment feature will be triggered, which will then pick 
+# members from the iOS-Dev team
+* @babylonhealth/ios-devs


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/IOSP-607

<!-- If you've added the "Blocked" label, also use one of these badges; don't forget to adapt the 3 NNNN values
  [![Blocked by #NNNN](https://img.shields.io/badge/Blocked%20by-%23NNNN-red)](https://github.com/babylonhealth/babylon-ios/pull/NNNN)
  ![Blocked by Current Release](https://img.shields.io/badge/Blocked%20by-Release%20N.N.N-red)
-->

### Why?
We want to migrate to GitHub's auto reviewer assignment in this repo. Updating the CODEOWNERS file to point to the `@babylonhealth/ios-devs` team will trigger GitHub's auto reviewer assignment.

### How?
Updated CODEOWNERS.

### Tested? (unit/automation/snapshot) 
Works for babylon-ios repo.

### PR checklist
* [x] I've set all the necessary PR's labels
* [x] If I touched files in the SDK, I've updated `SDK/CHANGELOG.md` and added `#SDK` in the PR title

With :heart:
