### PR TITLE
Add sprint's notice warning to a squad

### DIFF
--- a/Cookbook/Technical-Documents/ReleaseProcess.md
+++ b/Cookbook/Technical-Documents/ReleaseProcess.md
@@ -23,7 +23,9 @@
 When dealing with a particularly complicated bug (one that would require a rather significant effort to address) the release engineer should speak with Release Manager.  
 The bug's corresponding feature should be disabled altogether using its feature switch (if applicable). Such a bug would subsequently be handled by its respective squad.
 
-Release duties have priority over regular squad duties. Please inform your squad of your unavailability before starting to work in the release. As with every other week, twenty percent of your work hours overall are to be allocated towards making the release a reality.
+Release duties have priority over regular squad duties. Please inform your squad of your unavailability before starting to work in the release **with at least a sprint's notice**. As with every other week, twenty percent of your work hours overall are to be allocated towards making the release a reality.
+
+
 
 There are usually two release engineers working at any given time. It goes without saying that both engineers need to work together and that constant feedback is vital.
 


### PR DESCRIPTION
Added a note stating that we need to warn our squads with a sprint's notice, as requested [here](https://babylonhealth.slack.com/archives/GNYBQ06P5/p1582796110016800)