### PR TITLE
Update Apple Pay document

### DIFF
--- a/Cookbook/Technical-Documents/Apple_Pay.md
+++ b/Cookbook/Technical-Documents/Apple_Pay.md
@@ -6,17 +6,23 @@ Even if `ENABLE_APPLE_PAY` is present if the device is the simulator then Apple 
 # Apple Pay Testing
 
 Apple Pay can only be tested in a build which is compatible with App Store.
-The normal configuration of the project doesn't allow this, unless if we test a `Release` build on `TestFlight`.
+The normal configuration of the project doesn't allow this, unless we use a `Release` build from `TestFlight`.
 There is a lane which can configure the project in order to 
 - enable all the debugging mechanisms
 - make Apple Pay available
 
-Just execute `bundle exec fastlane setup_babylon_for_apple_pay_testing` and the project now is suitable for testing Apple Pay!
+Execute `bundle exec fastlane local_adhoc target:Babylon` and the project is now suitable for testing Apple Pay!
 
-Also there are some user sandbox accounts in `1Password`.
+There are some user sandbox accounts in `1Password` that are required when using Apple Pay.
 
 ### NOTICE
-After the execution of `bundle exec fastlane setup_babylon_for_apple_pay_testing` the project will be modified, these changes must __not__ 
+After the execution of `bundle exec fastlane local_adhoc target:Babylon` the project will be modified, these changes must __not__ 
 be added under VCS.
 
+### Code signing
 
+Due to the fact that the project configuration changes after running the lane mentioned above, and the team used is not the same one used for regular builds, you may run into problems running the app on your device.
+
+If this is the case, you'll find Xcode throwing an error that mentions that your device is not available for the provisioning profile used. In order to fix this, and since we currently don't have a lane to handle this scenario, you'll have to manually add the device to the developer portal.
+
+Once this has been done, you'll need to regenerate the provisioning profiles. For this, please refer to the [Fastlane Match](./FastlaneMatch.md) document. In case of doubt, make sure to check with other iOS engineers that can provide help with this before running anything that may regenerate a provisioning profile.

--- a/Cookbook/Technical-Documents/FastlaneMatch.md
+++ b/Cookbook/Technical-Documents/FastlaneMatch.md
@@ -86,8 +86,10 @@ Note: We specify `--app_identifier` so that other valid profiles are not re-gene
 
 - Run `bundle exec fastlane add_device` locally, it will ask you for the name of the device and its UDID, will add it to the Apple developer center for enterprise team and will automatically regenerate all development provisioning profiles.
 
-If something goes wrong with this lane you can follow manual steps:
-- You can also register your device manually on the portal in the enterprise team account
+After adding the device, the lane will ask for the bundle ids for the provisioning profiles that need to be regenerated. Check the target that you want to run, as some of them may require more than one in order to work. For example, the main target requires the notification service extension, which means that at least two provisionin profiles need to be generated.
+
+If something goes wrong with this lane you can follow these manual steps:
+- You can register your device manually on the portal in the enterprise team account
 - Run the following command
 
 ```


### PR DESCRIPTION
Updated lane name in the Apple Pay document, and added a section around code signing as we're not using our default configuration for running the app in this scenario.

Also updated the Fastlane document, as I got an extra step when I added my device.